### PR TITLE
INTERLOK-3095 Blocking init() on startup.

### DIFF
--- a/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
@@ -18,10 +18,6 @@ import com.adaptris.core.metadata.NoOpMetadataFilter;
 
 public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
   
-  private static final String PATH = "/workflow-services/*";
-  
-  private static final String ACCEPTED_FILTER = "POST,GET";
-  
   private static final String OK_200 = "200";
   
   private static final String ERROR_400 = "400";
@@ -36,7 +32,7 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
   }
   
   @Override
-  protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener) {
+  protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
     MetadataResponseHeaderProvider metadataResponseHeaderProvider = new MetadataResponseHeaderProvider();
     metadataResponseHeaderProvider.setFilter(new NoOpMetadataFilter());
     
@@ -46,8 +42,8 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
     EmbeddedConnection jettyConnection = new EmbeddedConnection();
     JettyMessageConsumer messageConsumer = new JettyMessageConsumer();
     
-    ConfiguredConsumeDestination configuredConsumeDestination = new ConfiguredConsumeDestination(PATH);
-    configuredConsumeDestination.setFilterExpression(ACCEPTED_FILTER);
+    ConfiguredConsumeDestination configuredConsumeDestination = new ConfiguredConsumeDestination(consumedUrlPath);
+    configuredConsumeDestination.setFilterExpression(acceptedHttpMethods);
     
     messageConsumer.setDestination(configuredConsumeDestination);
     messageConsumer.setHeaderHandler(new MetadataHeaderHandler(HEADER_PREFIX));

--- a/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
+++ b/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
@@ -155,8 +155,7 @@ public class WorkflowServicesComponent extends MgmtComponentImpl implements Adap
           getConsumer().setConsumedUrlPath(configuredUrlPath());
           getConsumer().setMessageListener(instance);
           getConsumer().prepare();
-          LifecycleHelper.init(getConsumer());
-          LifecycleHelper.start(getConsumer());
+          LifecycleHelper.initAndStart(getConsumer());
           
           log.debug("Workflow REST services component started.");
         } catch (CoreException e) {

--- a/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
+++ b/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
@@ -160,7 +160,7 @@ public class WorkflowServicesComponent extends MgmtComponentImpl implements Adap
           
           log.debug("Workflow REST services component started.");
         } catch (CoreException e) {
-          log.error("Could not start the Workflow REST services component.", e);
+          log.error("Could not start the Workflow REST services component '{}'", friendlyName(), e);
         }
       }
     }).start();

--- a/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
+++ b/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
@@ -2,7 +2,17 @@ package com.adaptris.rest;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.ObjectUtils;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -17,15 +27,15 @@ import com.adaptris.interlok.client.MessageTarget;
 import com.adaptris.interlok.client.jmx.InterlokJmxClient;
 import com.adaptris.interlok.types.SerializableMessage;
 
-import javax.management.*;
-
-import org.apache.commons.io.IOUtils;
-
 public class WorkflowServicesComponent extends MgmtComponentImpl implements AdaptrisMessageListener {
-  
-  private static final Long DEFAULT_INITIAL_JETTY_CONTEXT_WAIT = (30l*1000l);
-    
+      
   private static final String WORKFLOW_OBJ_NAME ="*com.adaptris:type=Workflow,*";
+  
+  private static final String BOOTSTRAP_PATH_KEY = "rest.workflow-services.path";
+  
+  private static final String DEFAULT_PATH = "/workflow-services/*";
+  
+  private static final String ACCEPTED_FILTER = "POST,GET";
   
   private static final String DEF_HEADER = "META-INF/definition-header.yaml";
   
@@ -56,12 +66,12 @@ public class WorkflowServicesComponent extends MgmtComponentImpl implements Adap
   private transient InterlokJmxClient jmxClient;
   
   private transient WorkflowTargetTranslator targetTranslator;
-  
-  private transient Long initialJettyContextWaitMs;
-  
+    
   private transient MBeanServer interlokMBeanServer;
   
   private transient AdaptrisMessageFactory messageFactory;
+  
+  private String configuredUrlPath;
   
   public WorkflowServicesComponent() {
     this.setConsumer(new HttpRestWorkflowServicesConsumer());
@@ -131,24 +141,25 @@ public class WorkflowServicesComponent extends MgmtComponentImpl implements Adap
   
   @Override
   public void init(Properties config) throws Exception {
-    this.getConsumer().setMessageListener(this);
-    this.getConsumer().prepare();
-    LifecycleHelper.init(getConsumer());
+    this.setConfiguredUrlPath(config.getProperty(BOOTSTRAP_PATH_KEY));
   }
 
   @Override
   public void start() throws Exception {
+    WorkflowServicesComponent instance = this;
     new Thread(new Runnable() {
-      
       @Override
       public void run() {
         try {
-          // Wait for the Jetty context to have been created.
-          Thread.sleep(initialJettyContextWaitMs());
+          getConsumer().setAcceptedHttpMethods(ACCEPTED_FILTER);
+          getConsumer().setConsumedUrlPath(configuredUrlPath());
+          getConsumer().setMessageListener(instance);
+          getConsumer().prepare();
+          LifecycleHelper.init(getConsumer());
           LifecycleHelper.start(getConsumer());
           
           log.debug("Workflow REST services component started.");
-        } catch (CoreException | InterruptedException e) {
+        } catch (CoreException e) {
           log.error("Could not start the Workflow REST services component.", e);
         }
       }
@@ -203,18 +214,6 @@ public class WorkflowServicesComponent extends MgmtComponentImpl implements Adap
     this.jmxClient = jmxClient;
   }
 
-  long initialJettyContextWaitMs() {
-    return this.getInitialJettyContextWaitMs() == null ? DEFAULT_INITIAL_JETTY_CONTEXT_WAIT : this.getInitialJettyContextWaitMs();
-  }
-  
-  public Long getInitialJettyContextWaitMs() {
-    return initialJettyContextWaitMs;
-  }
-
-  public void setInitialJettyContextWaitMs(Long initialJettyContextWaitMs) {
-    this.initialJettyContextWaitMs = initialJettyContextWaitMs;
-  }
-
   public MBeanServer getInterlokMBeanServer() {
     return interlokMBeanServer;
   }
@@ -229,6 +228,18 @@ public class WorkflowServicesComponent extends MgmtComponentImpl implements Adap
 
   public void setMessageFactory(AdaptrisMessageFactory messageFactory) {
     this.messageFactory = messageFactory;
+  }
+
+  String configuredUrlPath() {
+    return (String) ObjectUtils.defaultIfNull(this.getConfiguredUrlPath(), DEFAULT_PATH);
+  }
+  
+  public String getConfiguredUrlPath() {
+    return configuredUrlPath;
+  }
+
+  public void setConfiguredUrlPath(String configuredUrlPath) {
+    this.configuredUrlPath = configuredUrlPath;
   }
 
 }

--- a/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
@@ -14,8 +14,20 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
   private StandaloneConsumer standaloneConsumer;
   
   private AdaptrisMessageListener messageListener;
+  
+  /**
+   * This is the url that this consumer will listen for requests.
+   * For example "/workflow-services/*"; will trigger this consumer for any requests on "http://host:port/workflow-services/...".
+   */
+  private String consumedUrlPath;
+  
+  /**
+   * A comma separated list of accepted http request methods; GET, POST, PATCH etc etc
+   * And example might be "GET,POST".
+   */
+  private String acceptedHttpMethods;
     
-  protected abstract StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener);
+  protected abstract StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods);
   
   protected abstract void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage) throws ServiceException;
   
@@ -23,7 +35,7 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
 
   @Override
   public void prepare() throws CoreException {
-    this.setStandaloneConsumer(configureConsumer(this.getMessageListener()));
+    this.setStandaloneConsumer(configureConsumer(this.getMessageListener(), this.getConsumedUrlPath(), this.getAcceptedHttpMethods()));
     getStandaloneConsumer().prepare();
   }
   
@@ -61,6 +73,22 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
 
   public void setMessageListener(AdaptrisMessageListener messageListener) {
     this.messageListener = messageListener;
+  }
+
+  public String getConsumedUrlPath() {
+    return consumedUrlPath;
+  }
+
+  public void setConsumedUrlPath(String consumedUrlPath) {
+    this.consumedUrlPath = consumedUrlPath;
+  }
+
+  public String getAcceptedHttpMethods() {
+    return acceptedHttpMethods;
+  }
+
+  public void setAcceptedHttpMethods(String acceptedHttpMethods) {
+    this.acceptedHttpMethods = acceptedHttpMethods;
   }
   
 }

--- a/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
@@ -47,7 +47,7 @@ public class HttpRestWorkflowServicesConsumerTest extends TestCase {
       public String friendlyName() {
         return null;
       }
-    });
+    }, PATH, ACCEPTED_FILTER);
     
     assertEquals(PATH, standaloneConsumer.getConsumer().getDestination().getDestination());
     assertEquals(ACCEPTED_FILTER, standaloneConsumer.getConsumer().getDestination().getFilterExpression());

--- a/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 import javax.management.MBeanServer;
@@ -65,7 +66,6 @@ public class WorkflowServicesComponentTest extends TestCase {
     mockSerMessage = new SerializableAdaptrisMessage();
     
     workflowServicesComponent = new WorkflowServicesComponent();
-    workflowServicesComponent.setInitialJettyContextWaitMs(0l);
     workflowServicesComponent.setConsumer(mockConsumer);
     workflowServicesComponent.setJmxClient(mockJmxClient);
     
@@ -126,7 +126,7 @@ public class WorkflowServicesComponentTest extends TestCase {
   }
   
   private void startComponent() throws Exception {
-    workflowServicesComponent.init(null);
+    workflowServicesComponent.init(new Properties());
     workflowServicesComponent.start();
   }
   

--- a/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
@@ -23,6 +23,8 @@ public class WorkflowServicesConsumerTest extends TestCase {
     
     servicesConsumer = new HttpRestWorkflowServicesConsumer();
     servicesConsumer.setMessageListener(mockMessageListener);
+    servicesConsumer.setAcceptedHttpMethods("POST,GET");
+    servicesConsumer.setConsumedUrlPath("/myPath/");
   }
   
   public void testLifecycle() throws Exception {


### PR DESCRIPTION
The REST component was blocking Jetty starting up on init().
So we moved the blocking code from init() to start(), which is wrapped around a new thread.
This fixes the main bug.

Then we also re-factored a little to allow the jetty URL path to be configured in the bootstrap properties.
This bit might not be a big deal for this component, but might be very useful when we finally release the health-check component.
