### PR TITLE
INTERLOK-2984 Add JUnit annotations to tests

### DIFF
--- a/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
@@ -2,6 +2,9 @@ package com.adaptris.rest;
 
 import static org.mockito.Mockito.verify;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -26,7 +29,8 @@ public class HttpRestWorkflowServicesConsumerTest extends TestCase {
   private AdaptrisMessage processedMessage;
   
   @Mock private JettyResponseService mockResponseService;
-  
+
+  @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     
@@ -34,11 +38,13 @@ public class HttpRestWorkflowServicesConsumerTest extends TestCase {
     originalMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
     processedMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
   }
-  
+
+  @After
   public void tearDown() throws Exception {
     
   }
-  
+
+  @Test
   public void testCreateStandardConsumer() throws Exception {
     StandaloneConsumer standaloneConsumer = servicesConsumer.configureConsumer(new AdaptrisMessageListener() {
       @Override
@@ -52,7 +58,8 @@ public class HttpRestWorkflowServicesConsumerTest extends TestCase {
     assertEquals(PATH, standaloneConsumer.getConsumer().getDestination().getDestination());
     assertEquals(ACCEPTED_FILTER, standaloneConsumer.getConsumer().getDestination().getFilterExpression());
   }
-  
+
+  @Test
   public void testOkResponse() throws Exception {
     servicesConsumer.setResponseService(mockResponseService);
     servicesConsumer.doResponse(originalMessage, processedMessage);
@@ -61,6 +68,7 @@ public class HttpRestWorkflowServicesConsumerTest extends TestCase {
     verify(mockResponseService).doService(processedMessage);
   }
 
+  @Test
   public void testErrorResponse() throws Exception {
     servicesConsumer.setResponseService(mockResponseService);
     servicesConsumer.doErrorResponse(originalMessage, new Exception());

--- a/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
@@ -1,7 +1,9 @@
 package com.adaptris.rest;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 
+import com.adaptris.core.BaseCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,7 +18,7 @@ import com.adaptris.core.http.jetty.JettyResponseService;
 
 import junit.framework.TestCase;
 
-public class HttpRestWorkflowServicesConsumerTest extends TestCase {
+public class HttpRestWorkflowServicesConsumerTest extends BaseCase {
   
   private static final String PATH = "/workflow-services/*";
   
@@ -75,5 +77,10 @@ public class HttpRestWorkflowServicesConsumerTest extends TestCase {
     
     verify(mockResponseService).setHttpStatus("400");
     verify(mockResponseService).doService(originalMessage);
+  }
+
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
   }
 }

--- a/src/test/java/com/adaptris/rest/JettyConsumerWorkflowTargetTranslatorTest.java
+++ b/src/test/java/com/adaptris/rest/JettyConsumerWorkflowTargetTranslatorTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.rest;
 
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.BaseCase;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.interlok.client.MessageTarget;
@@ -9,7 +10,11 @@ import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JettyConsumerWorkflowTargetTranslatorTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class JettyConsumerWorkflowTargetTranslatorTest extends BaseCase {
   
   private static final String PATH_KEY = "jettyURI";
   
@@ -58,5 +63,9 @@ public class JettyConsumerWorkflowTargetTranslatorTest extends TestCase {
       // expected
     }
   }
-  
+
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
 }

--- a/src/test/java/com/adaptris/rest/JettyConsumerWorkflowTargetTranslatorTest.java
+++ b/src/test/java/com/adaptris/rest/JettyConsumerWorkflowTargetTranslatorTest.java
@@ -6,6 +6,8 @@ import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.interlok.client.MessageTarget;
 
 import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 public class JettyConsumerWorkflowTargetTranslatorTest extends TestCase {
   
@@ -14,12 +16,14 @@ public class JettyConsumerWorkflowTargetTranslatorTest extends TestCase {
   private AdaptrisMessage message;
   
   private JettyConsumerWorkflowTargetTranslator targetTranslator;
-  
+
+  @Before
   public void setUp() throws Exception {
     targetTranslator = new JettyConsumerWorkflowTargetTranslator();
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
   }
 
+  @Test
   public void testFullPathToWorkflow() throws Exception{
     message.addMessageHeader(PATH_KEY, "/workflow-services/myAdapter/myChannel/myWorkflow");
     MessageTarget target = targetTranslator.translateTarget(message);
@@ -28,20 +32,23 @@ public class JettyConsumerWorkflowTargetTranslatorTest extends TestCase {
     assertEquals("myChannel", target.getChannel());
     assertEquals("myWorkflow", target.getWorkflow());
   }
-  
+
+  @Test
   public void testRootReturnsNull() throws Exception{
     message.addMessageHeader(PATH_KEY, "/workflow-services/");
     MessageTarget target = targetTranslator.translateTarget(message);
     
     assertNull(target);
   }
-  
+
+  @Test
   public void testNoPathMetadataReturnsNull() throws Exception{
     MessageTarget target = targetTranslator.translateTarget(message);
     
     assertNull(target);
   }
-  
+
+  @Test
   public void testWrongNumberOfParams() throws Exception{
     message.addMessageHeader(PATH_KEY, "/workflow-services/1/2/3/4/5/6/7/");
     try {

--- a/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
@@ -1,5 +1,8 @@
 package com.adaptris.rest;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -59,7 +62,8 @@ public class WorkflowServicesComponentTest extends TestCase {
   private SerializableMessage mockSerMessage;
   
   private Set<ObjectInstance> mockReturnedWorkflows;
-  
+
+  @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     
@@ -76,11 +80,13 @@ public class WorkflowServicesComponentTest extends TestCase {
     mockReturnedWorkflows.add(new ObjectInstance(new ObjectName(WORKFLOW_OBJECT_TWO), WORKFLOW_MANAGER_CLASS));
     mockReturnedWorkflows.add(new ObjectInstance(new ObjectName(WORKFLOW_OBJECT_TWO), NOT_WORKFLOW_MANAGER_CLASS));
   }
-  
+
+  @After
   public void tearDown() throws Exception {
     stopComponent();
   }
-  
+
+  @Test
   public void testHappyPathMessageProcessed() throws Exception {
     startComponent();
     
@@ -93,7 +99,8 @@ public class WorkflowServicesComponentTest extends TestCase {
     verify(mockJmxClient).process(any(), any());
     verify(mockConsumer).doResponse(any(), any());
   }
-  
+
+  @Test
   public void testYamlDefRequest() throws Exception {
     startComponent();
     
@@ -102,7 +109,8 @@ public class WorkflowServicesComponentTest extends TestCase {
     
     verify(mockJmxClient, times(0)).process(any(), any());
   }
-  
+
+  @Test
   public void testProcessingWorkflowsDefinition() throws Exception {
     startComponent();
     
@@ -122,7 +130,8 @@ public class WorkflowServicesComponentTest extends TestCase {
     assertTrue(returnedMessage.getContent().contains("standard-workflow-1"));
     assertTrue(returnedMessage.getContent().contains("standard-workflow-2"));
   }
-  
+
+  @Test
   public void testInitFails() throws Exception {
     doThrow(new CoreException("Expected"))
         .when(mockConsumer).init();
@@ -132,7 +141,8 @@ public class WorkflowServicesComponentTest extends TestCase {
     // If the init fails, then start shuld not run.
     verify(mockConsumer, times(0)).start();
   }
-  
+
+  @Test
   public void testErrorResponse() throws Exception {
     startComponent();
     

--- a/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
@@ -1,11 +1,13 @@
 package com.adaptris.rest;
 
+import com.adaptris.core.BaseCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +33,7 @@ import com.adaptris.interlok.types.SerializableMessage;
 
 import junit.framework.TestCase;
 
-public class WorkflowServicesComponentTest extends TestCase {
+public class WorkflowServicesComponentTest extends BaseCase {
   
   private static final String PATH_KEY = "jettyURI";
   
@@ -163,4 +165,8 @@ public class WorkflowServicesComponentTest extends TestCase {
     workflowServicesComponent.destroy();
   }
 
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
 }

--- a/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
@@ -2,6 +2,7 @@ package com.adaptris.rest;
 
 import static org.mockito.Mockito.verify;
 
+import com.adaptris.core.BaseCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -12,7 +13,7 @@ import com.adaptris.core.StandaloneConsumer;
 
 import junit.framework.TestCase;
 
-public class WorkflowServicesConsumerTest extends TestCase {
+public class WorkflowServicesConsumerTest extends BaseCase {
   
   private WorkflowServicesConsumer servicesConsumer;
   
@@ -46,4 +47,8 @@ public class WorkflowServicesConsumerTest extends TestCase {
     verify(mockStandaloneConsumer).requestClose();
   }
 
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
 }

--- a/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
@@ -2,6 +2,8 @@ package com.adaptris.rest;
 
 import static org.mockito.Mockito.verify;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -17,7 +19,8 @@ public class WorkflowServicesConsumerTest extends TestCase {
   @Mock private StandaloneConsumer mockStandaloneConsumer;
   
   @Mock private AdaptrisMessageListener mockMessageListener;
-  
+
+  @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     
@@ -26,7 +29,8 @@ public class WorkflowServicesConsumerTest extends TestCase {
     servicesConsumer.setAcceptedHttpMethods("POST,GET");
     servicesConsumer.setConsumedUrlPath("/myPath/");
   }
-  
+
+  @Test
   public void testLifecycle() throws Exception {
     servicesConsumer.prepare();
     


### PR DESCRIPTION
Add the annotations that JUint 4+ use to identify tests, as well as setup/clean-up methods.