### PR TITLE
Feature/interlok 3208 rest endpoint for clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bin
 gradle.properties
 unit-tests.properties
 /.gradle/
+*/src/main/generated

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,6 +3,8 @@ extraction:
     index:
       gradle:
         version: 5.6.3
+      build_command:
+        - ./gradlew --no-daemon -S lgtmCompile
 
 path_classifiers:
   docs:
@@ -17,3 +19,5 @@ path_classifiers:
     - ".dependabot"
     - ".github"
     - ".lgtm.yml"
+  generated:
+    exclude: "**/*.java"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![GitHub tag](https://img.shields.io/github/tag/adaptris/interlok-workflow-rest-services.svg)](https://github.com/adaptris/interlok-workflow-rest-services/tags) [![Build Status](https://travis-ci.org/adaptris/interlok-workflow-rest-services.svg?branch=develop)](https://travis-ci.org/adaptris/interlok-workflow-rest-services) [![CircleCI](https://circleci.com/gh/adaptris/interlok-workflow-rest-services/tree/develop.svg?style=svg)](https://circleci.com/gh/adaptris/interlok-workflow-rest-services/tree/develop) [![codecov](https://codecov.io/gh/adaptris/interlok-workflow-rest-services/branch/develop/graph/badge.svg)](https://codecov.io/gh/adaptris/interlok-workflow-rest-services) [![Total alerts](https://img.shields.io/lgtm/alerts/g/adaptris/interlok-workflow-rest-services.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adaptris/interlok-workflow-rest-services/alerts/) [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/adaptris/interlok-workflow-rest-services.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adaptris/interlok-workflow-rest-services/context:java)
 
-REST style API into the Interlok workflows.
+REST style API for Interlok.
 
 ## Health-Check
+
+Allows you to see a status (started, stopped, etc) of all Interlok channels and workflows in JSON form.
 
 ### Installation
 
@@ -64,6 +66,47 @@ Below is an example of the resulting JSON.
   ]
 }
 ```
+
+## Cluster Manager
+
+Allows you to see a full list of known Interlok cluster instances in this instances cluster; JSON formatted.
+
+### Installation
+
+Drop the __interlok-workflow-rest-services.jar__ built from this project in to your Interlok __lib__ directory, then modify your __bootstrap.properties__ to make sure the managementComponents property contains all of "__jetty__", "__jmx__, "__cluster__", " and "__cluster-rest__".
+```
+managementComponents=jetty:jmx:cluster
+```
+
+The __cluster__ component enables basic clustering, __cluster-rest__ enables querying of the known instances.
+
+Optionally, you can also set the property named __rest.cluster-manager.path__, which directly affects the REST API URL path.  The default value is; "__/cluster-manager/*__".
+
+### Running
+
+Using your favourite HTTP GET/POST tool, make a GET request to the running Interlok instance;
+```
+http GET http://<host>:<port>/cluster-manager
+```
+
+This will return a JSON array, with all of the known cluster instances.
+
+Below is an example of the resulting JSON.
+
+```json
+{
+  "java.util.Collection": [
+    {
+      "com.adaptris.mgmt.cluster.ClusterInstance": {
+        "cluster-uuid": "97015aa0-f9b8-4bd1-93fb-01922b827d08",
+        "jmx-address": "service:jmx:jmxmp://localhost:5555",
+        "unique-id": "MyInterlokInstance"
+      }
+    }
+  ]
+}
+```
+
 
 ## Workflow Rest Services
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ ext {
   repoPassword = project.hasProperty('repoPassword') ? project.getProperty('repoPassword') : 'unknown'
   defaultNexusRepo = project.hasProperty('defaultNexusRepo') ? project.getProperty('defaultNexusRepo') : 'https://repo1.maven.org/maven2/'
 
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
+
   offlineJavadocPackageDir = new File(project.buildDir, "offline-javadoc-packages")
   interlokJavadocs= project.hasProperty('interlokJavadocs') ? project.getProperty('interlokJavadocs') : javadocsBaseUrl + "/interlok-core/" + interlokCoreVersion
   interlokCommonJavadocs= project.hasProperty('interlokJavadocs') ? project.getProperty('interlokJavadocs') : javadocsBaseUrl + "/interlok-common/" + interlokCoreVersion
@@ -320,6 +322,26 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
     xml.enabled = false
     html.enabled = true
   }
+}
+
+delombok {
+  target = delombokTargetDir
+}
+
+task lgtmCompile(type: JavaCompile, dependsOn: delombok) {
+  group 'Build'
+  description 'Compile for lgtm'
+
+  source = sourceSets.main.extensions.delombokTask
+  destinationDir = sourceSets.main.java.outputDir
+  classpath = project.sourceSets.main.compileClasspath
+}
+
+
+task deleteGeneratedFiles(type: Delete) {
+  delete 'activemq-data'
+  delete 'data'
+  delete delombokTargetDir
 }
 
 check.dependsOn jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,8 @@ dependencies {
 
   compile ("com.adaptris:interlok-client-jmx:$interlokCoreVersion") { changing= true}
   compile ("com.adaptris:interlok-client:$interlokCoreVersion") { changing= true}
+  
+  compile  ("com.adaptris:interlok-cluster-manager:$interlokCoreVersion") { changing= true}
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
   umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")

--- a/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
+++ b/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
@@ -1,0 +1,67 @@
+package com.adaptris.rest;
+
+import java.util.Properties;
+
+import com.adaptris.core.AdaptrisMessageListener;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.management.MgmtComponentImpl;
+import com.adaptris.core.util.LifecycleHelper;
+
+public abstract class AbstractRestfulEndpoint extends MgmtComponentImpl implements AdaptrisMessageListener {
+
+  public AbstractRestfulEndpoint() {
+    this.setConsumer(new HttpRestWorkflowServicesConsumer());
+  }
+  
+  private transient WorkflowServicesConsumer consumer;
+  
+  @Override
+  public void init(Properties config) throws Exception {
+  }
+
+  @Override
+  public void start() throws Exception {
+    AbstractRestfulEndpoint instance = this;
+    new Thread(() -> {
+      try {
+        getConsumer().setAcceptedHttpMethods(getAcceptedFilter());
+        getConsumer().setConsumedUrlPath(getConfiguredUrlPath());
+        getConsumer().setMessageListener(instance);
+        LifecycleHelper.initAndStart(getConsumer());
+
+        log.debug(friendlyName() + " component started.");
+      } catch (CoreException e) {
+        log.error("Could not start the Cluster Manager REST services component.", e);
+      }
+    }).start();
+  }
+  
+  protected abstract String getAcceptedFilter();
+  
+  protected abstract String getConfiguredUrlPath();
+  
+  @Override
+  public String friendlyName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
+  public void stop() throws Exception {
+    LifecycleHelper.stop(getConsumer());
+    
+    log.debug(friendlyName() + " component stopped.");
+  }
+
+  @Override
+  public void destroy() throws Exception {
+    LifecycleHelper.close(getConsumer());
+  }
+  
+  public WorkflowServicesConsumer getConsumer() {
+    return consumer;
+  }
+
+  public void setConsumer(WorkflowServicesConsumer consumer) {
+    this.consumer = consumer;
+  }
+}

--- a/src/main/java/com/adaptris/rest/ClusterManagerComponent.java
+++ b/src/main/java/com/adaptris/rest/ClusterManagerComponent.java
@@ -1,0 +1,85 @@
+package com.adaptris.rest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.XStreamJsonMarshaller;
+import com.adaptris.mgmt.cluster.ClusterInstance;
+import com.adaptris.mgmt.cluster.mbean.ClusterManagerMBean;
+import com.adaptris.rest.util.JmxMBeanHelper;
+
+public class ClusterManagerComponent extends AbstractRestfulEndpoint {
+
+  private static final String BOOTSTRAP_PATH_KEY = "rest.cluster-manager.path";
+
+  private static final String ACCEPTED_FILTER = "GET";
+
+  private static final String DEFAULT_PATH = "/cluster-manager/*";
+
+  private static final String CLUSTER_MANAGER_OBJECT_NAME = "com.adaptris:type=ClusterManager,id=ClusterManager";
+  
+  private transient JmxMBeanHelper jmxMBeanHelper;
+
+  private String configuredUrlPath;
+
+  public ClusterManagerComponent () {
+    super();
+    this.setJmxMBeanHelper(new JmxMBeanHelper());
+  }
+
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage message, java.util.function.Consumer<AdaptrisMessage> onSuccess) {
+    try {
+      ClusterManagerMBean clusterManager = this.getJmxMBeanHelper().proxyMBean(CLUSTER_MANAGER_OBJECT_NAME, ClusterManagerMBean.class);
+      
+      final List<ClusterInstance> clusterInstances = new ArrayList<ClusterInstance>();
+      clusterManager.getClusterInstances().getKeys().forEach(key -> {
+        try {
+          clusterInstances.add((ClusterInstance) clusterManager.getClusterInstances().get(key));
+        } catch (CoreException e) {}
+      });
+      String jsonString = new XStreamJsonMarshaller().marshal(clusterInstances);
+      message.setContent(jsonString, message.getContentEncoding());
+      
+      this.getConsumer().doResponse(message, message);
+    } catch (Exception ex) {
+      try {
+        this.getConsumer().doErrorResponse(message, ex);
+      } catch (ServiceException e) {
+      }
+    }
+  }
+
+  @Override
+  public void init(Properties config) throws Exception {
+    super.init(config);
+    this.setConfiguredUrlPath(config.getProperty(BOOTSTRAP_PATH_KEY));
+  }
+
+  public String getConfiguredUrlPath() {
+    return ObjectUtils.defaultIfNull(configuredUrlPath, DEFAULT_PATH);
+  }
+
+  public void setConfiguredUrlPath(String configuredUrlPath) {
+    this.configuredUrlPath = configuredUrlPath;
+  }
+
+  public JmxMBeanHelper getJmxMBeanHelper() {
+    return jmxMBeanHelper;
+  }
+
+  public void setJmxMBeanHelper(JmxMBeanHelper jmxMBeanHelper) {
+    this.jmxMBeanHelper = jmxMBeanHelper;
+  }
+
+  @Override
+  protected String getAcceptedFilter() {
+    return ACCEPTED_FILTER;
+  }
+}

--- a/src/main/java/com/adaptris/rest/util/JmxMBeanHelper.java
+++ b/src/main/java/com/adaptris/rest/util/JmxMBeanHelper.java
@@ -1,8 +1,10 @@
-package com.adaptris.rest.healthcheck;
+package com.adaptris.rest.util;
 
 import java.util.Set;
 
+import javax.management.JMX;
 import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 
@@ -21,6 +23,10 @@ public class JmxMBeanHelper {
   
   public String getStringAttributeClassName(String objectName, String attributeName) throws Exception {
     return (String) mBeanServer().getAttribute(new ObjectName(objectName), attributeName).getClass().getSimpleName();
+  }
+  
+  public <T> T proxyMBean(String objectNameString, Class<T> type) throws MalformedObjectNameException {
+    return (T) JMX.newMBeanProxy(mBeanServer(), new ObjectName(objectNameString), type, true);
   }
   
   @SuppressWarnings("unchecked")

--- a/src/main/resources/META-INF/com/adaptris/core/management/components/cluster-rest
+++ b/src/main/resources/META-INF/com/adaptris/core/management/components/cluster-rest
@@ -1,0 +1,1 @@
+class=com.adaptris.rest.ClusterManagerComponent

--- a/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
+++ b/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
@@ -1,0 +1,189 @@
+package com.adaptris.rest;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+import javax.management.MalformedObjectNameException;
+
+import org.awaitility.Durations;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageListener;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.StandaloneConsumer;
+import com.adaptris.core.XStreamJsonMarshaller;
+import com.adaptris.core.cache.ExpiringMapCache;
+import com.adaptris.mgmt.cluster.ClusterInstance;
+import com.adaptris.mgmt.cluster.mbean.ClusterManagerMBean;
+import com.adaptris.rest.util.JmxMBeanHelper;
+
+public class ClusterManagerComponentTest {
+  
+  private static final String CLUSTER_MANAGER_OBJECT_NAME = "com.adaptris:type=ClusterManager,id=ClusterManager";
+  
+  private ClusterManagerComponent clusterManagerComponent;
+  
+  private TestConsumer testConsumer = new TestConsumer();
+  
+  private ExpiringMapCache expiringMapCache;
+  
+  private ClusterInstance clusterInstanceOne;
+  
+  private ClusterInstance clusterInstanceTwo;
+  
+  private AdaptrisMessage message;
+  
+  @Mock private JmxMBeanHelper mockJmxHelper;
+  
+  @Mock private ClusterManagerMBean mockClusterManagerMBean;
+  
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    
+    clusterManagerComponent = new ClusterManagerComponent();
+    clusterManagerComponent.setJmxMBeanHelper(mockJmxHelper);
+    clusterManagerComponent.setConsumer(testConsumer);
+    
+    clusterManagerComponent.init(new Properties());
+    clusterManagerComponent.start();
+    
+    expiringMapCache = new ExpiringMapCache();
+    expiringMapCache.init();
+    
+    clusterInstanceOne = new ClusterInstance(UUID.randomUUID(), "id-1", "jms-address-1");
+    clusterInstanceTwo = new ClusterInstance(UUID.randomUUID(), "id-2", "jms-address-2");
+    
+    when(mockJmxHelper.proxyMBean(CLUSTER_MANAGER_OBJECT_NAME, ClusterManagerMBean.class))
+        .thenReturn(mockClusterManagerMBean);
+    when(mockClusterManagerMBean.getClusterInstances())
+        .thenReturn(expiringMapCache);
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    clusterManagerComponent.stop();
+    clusterManagerComponent.destroy();
+  }
+
+  @Test
+  public void testNoClusters() throws Exception {
+    clusterManagerComponent.onAdaptrisMessage(message);
+    
+    await()
+      .atMost(Durations.FIVE_SECONDS)
+    .with()
+      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+      .until(testConsumer::complete);
+  
+    // assert no cluster instances;
+    assertFalse(testConsumer.payload.contains("instance"));
+  }
+  
+  @Test
+  public void testMyOwnClusterInstance() throws Exception {
+    expiringMapCache.put(clusterInstanceOne.getUniqueId(), clusterInstanceOne);
+    
+    clusterManagerComponent.onAdaptrisMessage(message);
+    
+    await()
+      .atMost(Durations.FIVE_SECONDS)
+    .with()
+      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+      .until(testConsumer::complete);
+  
+    @SuppressWarnings("unchecked")
+    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
+    
+    assertTrue(instances.size() == 1);
+    assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
+    assertTrue(instances.get(0).getClusterUuid().equals(clusterInstanceOne.getClusterUuid()));
+    assertTrue(instances.get(0).getJmxAddress().equals(clusterInstanceOne.getJmxAddress()));
+  }
+  
+  @Test
+  public void testMultipleClusterInstances() throws Exception {
+    expiringMapCache.put(clusterInstanceOne.getUniqueId(), clusterInstanceOne);
+    expiringMapCache.put(clusterInstanceTwo.getUniqueId(), clusterInstanceTwo);
+    
+    clusterManagerComponent.onAdaptrisMessage(message);
+    
+    await()
+      .atMost(Durations.FIVE_SECONDS)
+    .with()
+      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+      .until(testConsumer::complete);
+  
+    @SuppressWarnings("unchecked")
+    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
+    
+    assertTrue(instances.size() == 2);
+    assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
+    assertTrue(instances.get(0).getClusterUuid().equals(clusterInstanceOne.getClusterUuid()));
+    assertTrue(instances.get(0).getJmxAddress().equals(clusterInstanceOne.getJmxAddress()));
+    
+    assertTrue(instances.get(1).getUniqueId().equals(clusterInstanceTwo.getUniqueId()));
+    assertTrue(instances.get(1).getClusterUuid().equals(clusterInstanceTwo.getClusterUuid()));
+    assertTrue(instances.get(1).getJmxAddress().equals(clusterInstanceTwo.getJmxAddress()));
+  }
+  
+  @Test
+  public void testMBeansNotAvailable() throws Exception {
+    doThrow(new MalformedObjectNameException("expected"))
+        .when(mockJmxHelper).proxyMBean(CLUSTER_MANAGER_OBJECT_NAME, ClusterManagerMBean.class);
+        
+    clusterManagerComponent.onAdaptrisMessage(message);
+    
+    await()
+      .atMost(Durations.FIVE_SECONDS)
+    .with()
+      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+      .until(testConsumer::complete);
+  
+    assertTrue(testConsumer.isError);
+  }
+  
+  class TestConsumer extends WorkflowServicesConsumer {
+    
+    String payload;
+    boolean isError;
+
+    @Override
+    protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
+      return null;
+    }
+
+    @Override
+    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage) throws ServiceException {
+      payload = processedMessage.getContent();
+    }
+
+    @Override
+    public void doErrorResponse(AdaptrisMessage message, Exception e) throws ServiceException {
+      isError = true;
+    }
+    
+    public boolean complete() {
+      return isError == true || payload != null;
+    }
+    
+    public void prepare() {
+      
+    }
+  }
+}

--- a/src/test/java/com/adaptris/rest/WorkflowHealthCheckComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowHealthCheckComponentTest.java
@@ -31,7 +31,7 @@ import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StartedState;
 import com.adaptris.core.StoppedState;
 import com.adaptris.core.runtime.AdapterManager;
-import com.adaptris.rest.healthcheck.JmxMBeanHelper;
+import com.adaptris.rest.util.JmxMBeanHelper;
 
 public class WorkflowHealthCheckComponentTest {
   


### PR DESCRIPTION
## Motivation

We have a cluster manager which will communicate and keep tabs on the cluster instances.  This comes with a JMX endpoint to query the known instances in the cluster.  To make it more user friendly, we're adding a REST endpoint to also return this information.

## Modification

I've modified the workflow-rest project, as that seems to be where our REST API leaves at the moment.  We have a new management component called "cluster-rest", which exposes the new service.

I think we are going to need to consider the project structure of workflow-services as it grows...  So for now, I have abstracted out much of the web-servicey stuff from each available API endpoint; health-check, cluster-rest, workflow-rest.  It means that we "can" add new endpoints relatively easily by extending the abstract endpoint class. 

## Result

A new management component named "cluster-rest", which adds a new servlet to our embedded Jetty server listening on the default url of ".../cluster-manager/*", wwhich will return a JSON style array of known Interlok instances in the cluster.

## Testing

Check the readme for instructions on setup, then simply do a "GET" to the servlet entry;
"http://<host>:<port>/cluster-manager".

You'll get some nice JSON in the response.