### PR TITLE
INTERLOK-3222 Hide java.util.Collection entry

### DIFF
--- a/src/main/java/com/adaptris/rest/ClusterManagerComponent.java
+++ b/src/main/java/com/adaptris/rest/ClusterManagerComponent.java
@@ -54,7 +54,7 @@ public class ClusterManagerComponent extends AbstractRestfulEndpoint {
       String jsonString = new XStreamJsonMarshaller().marshal(clusterInstances);
       message.setContent(jsonString, message.getContentEncoding());
       
-      this.getConsumer().doResponse(message, message);
+      this.getConsumer().doResponse(message, message, HttpRestWorkflowServicesConsumer.CONTENT_TYPE_JSON);
     } catch (Exception ex) {
       sendErrorResponseQuietly(getConsumer(), message, ex);
     } finally {

--- a/src/main/java/com/adaptris/rest/healthcheck/AdapterList.java
+++ b/src/main/java/com/adaptris/rest/healthcheck/AdapterList.java
@@ -1,0 +1,62 @@
+package com.adaptris.rest.healthcheck;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * List of adapters that will be returned by the healthcheck
+ * 
+ */
+@XStreamAlias("adapters")
+public class AdapterList extends AbstractList<AdapterState> {
+
+  @Getter
+  @Setter
+  @XStreamImplicit(itemFieldName = "adapter-state")
+  private List<AdapterState> adapterStates;
+
+  public AdapterList() {
+    setAdapterStates(new ArrayList<>());
+  }
+
+
+  public static AdapterList wrap(List<AdapterState> states) {
+    AdapterList list = new AdapterList();
+    list.setAdapterStates(states);
+    return list;
+  }
+
+
+  @Override
+  public AdapterState get(int index) {
+    return getAdapterStates().get(index);
+  }
+
+  @Override
+  public int size() {
+    return getAdapterStates().size();
+  }
+
+
+  @Override
+  public Iterator<AdapterState> iterator() {
+    return getAdapterStates().iterator();
+  }
+
+  @Override
+  public boolean add(AdapterState x) {
+    return getAdapterStates().add(x);
+  }
+
+  @Override
+  public void add(int index, AdapterState x) {
+    getAdapterStates().add(index, x);
+  }
+
+}

--- a/src/main/java/com/adaptris/rest/healthcheck/AdapterState.java
+++ b/src/main/java/com/adaptris/rest/healthcheck/AdapterState.java
@@ -4,21 +4,28 @@ import java.util.ArrayList;
 import java.util.List;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @XStreamAlias("adapter-state")
-public class AdapterState {
-  @Getter
-  @Setter
-  private String id;
-  @Getter
-  @Setter
-  private String state;
+@NoArgsConstructor
+public class AdapterState extends State {
+
+  // Defaults to "null" to avoid [""] as the output; better for it to be not present rather than
+  // the wrong type?
   @Getter
   @Setter
   private List<ChannelState> channelStates;
 
-  public AdapterState() {
-    this.setChannelStates(new ArrayList<>());
+  public AdapterState withChannelStates(List<ChannelState> states) {
+    setChannelStates(states);
+    return this;
+  }
+
+  public List<ChannelState> applyDefaultIfNull() {
+    if (getChannelStates() == null) {
+      return withChannelStates(new ArrayList<>()).getChannelStates();
+    }
+    return getChannelStates();
   }
 }

--- a/src/main/java/com/adaptris/rest/healthcheck/ChannelState.java
+++ b/src/main/java/com/adaptris/rest/healthcheck/ChannelState.java
@@ -4,22 +4,27 @@ import java.util.ArrayList;
 import java.util.List;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @XStreamAlias("channel-state")
-public class ChannelState {
-  @Getter
-  @Setter
-  private String id;
-  @Getter
-  @Setter
-  private String state;
+@NoArgsConstructor
+public class ChannelState extends State {
+  // Defaults to "null" to avoid [""] as the output; better for it to be not present rather than
+  // the wrong type?
   @Getter
   @Setter
   private List<WorkflowState> workflowStates;
 
-  public ChannelState() {
-    this.setWorkflowStates(new ArrayList<>());
+  public ChannelState withWorkflowStates(List<WorkflowState> states) {
+    setWorkflowStates(states);
+    return this;
   }
 
+  public List<WorkflowState> applyDefaultIfNull() {
+    if (getWorkflowStates() == null) {
+      return withWorkflowStates(new ArrayList<>()).getWorkflowStates();
+    }
+    return getWorkflowStates();
+  }
 }

--- a/src/main/java/com/adaptris/rest/healthcheck/State.java
+++ b/src/main/java/com/adaptris/rest/healthcheck/State.java
@@ -1,0 +1,28 @@
+package com.adaptris.rest.healthcheck;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+public abstract class State {
+  @Getter
+  @Setter
+  private String id;
+  @Getter
+  @Setter
+  private String state;
+
+
+  @SuppressWarnings("unchecked")
+  public <T extends State> T withId(String s) {
+    setId(s);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends State> T withState(String s) {
+    setState(s);
+    return (T) this;
+  }
+}

--- a/src/main/java/com/adaptris/rest/healthcheck/WorkflowState.java
+++ b/src/main/java/com/adaptris/rest/healthcheck/WorkflowState.java
@@ -1,18 +1,9 @@
 package com.adaptris.rest.healthcheck;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @XStreamAlias("workflow-state")
 @NoArgsConstructor
-public class WorkflowState {
-  @Getter
-  @Setter
-  private String id;
-  @Getter
-  @Setter
-  private String state;
-
+public class WorkflowState extends State {
 }

--- a/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
+++ b/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
@@ -5,20 +5,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
-
 import javax.management.MalformedObjectNameException;
-
 import org.awaitility.Durations;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.DefaultMessageFactory;
@@ -169,12 +165,14 @@ public class ClusterManagerComponentTest {
     }
 
     @Override
-    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage) throws ServiceException {
+    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage, String contentType)
+        throws ServiceException {
       payload = processedMessage.getContent();
     }
 
+
     @Override
-    public void doErrorResponse(AdaptrisMessage message, Exception e) throws ServiceException {
+    public void doErrorResponse(AdaptrisMessage message, Exception e, String contentType) throws ServiceException {
       isError = true;
     }
     
@@ -182,6 +180,7 @@ public class ClusterManagerComponentTest {
       return isError == true || payload != null;
     }
     
+    @Override
     public void prepare() {
       
     }

--- a/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
@@ -67,7 +67,7 @@ public class HttpRestWorkflowServicesConsumerTest {
   @Test
   public void testErrorResponse() throws Exception {
     servicesConsumer.setResponseService(mockResponseService);
-    servicesConsumer.doErrorResponse(originalMessage, new Exception());
+    servicesConsumer.doErrorResponse(originalMessage, new Exception(), null);
 
     verify(mockResponseService).doService(originalMessage);
   }

--- a/src/test/java/com/adaptris/rest/WorkflowHealthCheckComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowHealthCheckComponentTest.java
@@ -7,21 +7,17 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
-
 import org.awaitility.Durations;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.DefaultMessageFactory;
@@ -213,8 +209,7 @@ public class WorkflowHealthCheckComponentTest {
     .with()
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
-    
-    assertEquals("{\"java.util.Collection\":[\"\"]}", testConsumer.payload);
+    assertEquals("{\"adapters\":[\"\"]}", testConsumer.payload);
   }
   
   @Test
@@ -230,7 +225,6 @@ public class WorkflowHealthCheckComponentTest {
     .with()
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
-    
     assertTrue(testConsumer.payload.contains(ADAPTER_ID));
     assertTrue(testConsumer.payload.contains(CHANNEL_ID));
     assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
@@ -270,12 +264,14 @@ public class WorkflowHealthCheckComponentTest {
     }
 
     @Override
-    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage) throws ServiceException {
+    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage, String contentType)
+        throws ServiceException {
       payload = processedMessage.getContent();
     }
 
+
     @Override
-    public void doErrorResponse(AdaptrisMessage message, Exception e) throws ServiceException {
+    public void doErrorResponse(AdaptrisMessage message, Exception e, String contentType) throws ServiceException {
       isError = true;
     }
     
@@ -283,6 +279,7 @@ public class WorkflowHealthCheckComponentTest {
       return isError == true || payload != null;
     }
     
+    @Override
     public void prepare() {
       
     }

--- a/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
@@ -144,7 +144,7 @@ public class WorkflowServicesComponentTest {
     workflowServicesComponent.onAdaptrisMessage(message);
     
     verify(mockJmxClient, times(0)).process(any(), any());
-    verify(mockConsumer).doErrorResponse(any(), any());
+    verify(mockConsumer).doErrorResponse(any(), any(), any());
   }
   
   private void startComponent() throws Exception {

--- a/src/test/java/com/adaptris/rest/healthcheck/AdapterListTest.java
+++ b/src/test/java/com/adaptris/rest/healthcheck/AdapterListTest.java
@@ -1,0 +1,63 @@
+package com.adaptris.rest.healthcheck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import com.adaptris.core.XStreamJsonMarshaller;
+
+public class AdapterListTest {
+
+  @Test
+  public void testSize() {
+    List<AdapterState> list = build();
+    AdapterList adapterList = AdapterList.wrap(list);
+    assertEquals(1, adapterList.size());
+  }
+
+  @Test
+  public void testGetInt() {
+    List<AdapterState> list = build();
+    AdapterList adapterList = AdapterList.wrap(list);
+    assertEquals(1, adapterList.size());
+    assertNotNull(adapterList.get(0));
+  }
+
+  @Test
+  public void testIterator() {
+    List<AdapterState> list = build();
+    AdapterList adapterList = AdapterList.wrap(list);
+    assertEquals(1, adapterList.size());
+    assertNotNull(adapterList.iterator());
+    assertEquals(AdapterState.class, adapterList.iterator().next().getClass());
+  }
+
+  @Test
+  public void testAddAdapterState() throws Exception {
+    AdapterList adapterList = new AdapterList();
+    adapterList.add(new AdapterState().withId("adapter1").withState("ClosedState"));
+    adapterList.add(adapterList.size(), new AdapterState().withId("adapter2").withState("ClosedState"));
+    assertEquals(2, adapterList.size());
+    System.err.println(new XStreamJsonMarshaller().marshal(adapterList));
+  }
+
+
+  private List<AdapterState> build() {
+    List<WorkflowState> c1ws = new ArrayList<>(Arrays.asList(
+        new WorkflowState().withId("c1w1").withState("StartedState")
+        ,new WorkflowState().withId("c1w2").withState("StartedState")));
+    List<WorkflowState> c2ws = new ArrayList<>(Arrays.asList(
+        new WorkflowState().withId("c2w1").withState("StartedState")
+        ,new WorkflowState().withId("c2w2").withState("StartedState")));
+    List<ChannelState> channelStates = new ArrayList<ChannelState>(Arrays.asList(
+        (ChannelState) new ChannelState().withWorkflowStates(c1ws).withId("c1").withState("StartedState"),
+        (ChannelState) new ChannelState().withWorkflowStates(c2ws).withId("c2").withState("StartedState")
+        ));
+    
+    List<AdapterState> list =
+        Arrays.asList(new AdapterState().withChannelStates(channelStates).withId("MyAdapter").withState("StartedState"));
+    return new ArrayList<>(list);
+  }
+}

--- a/src/test/java/com/adaptris/rest/healthcheck/AdapterStateTest.java
+++ b/src/test/java/com/adaptris/rest/healthcheck/AdapterStateTest.java
@@ -1,0 +1,29 @@
+package com.adaptris.rest.healthcheck;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class AdapterStateTest {
+
+  @Test
+  public void testWithChannelStates() {
+    AdapterState state = new AdapterState().withId("id").withState("state");
+    assertNull(state.getChannelStates());
+    state.withChannelStates(new ArrayList());
+    assertNotNull(state.getChannelStates());
+  }
+
+  @Test
+  public void testApplyDefaultIfNull() {
+    AdapterState state = new AdapterState();
+    assertNull(state.getChannelStates());
+    List<ChannelState> s1 = state.applyDefaultIfNull();
+    List<ChannelState> s2 = state.applyDefaultIfNull();
+    assertSame(s1, s2);
+    assertNotNull(state.getChannelStates());
+  }
+}

--- a/src/test/java/com/adaptris/rest/healthcheck/ChannelStateTest.java
+++ b/src/test/java/com/adaptris/rest/healthcheck/ChannelStateTest.java
@@ -1,0 +1,30 @@
+package com.adaptris.rest.healthcheck;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class ChannelStateTest {
+
+  @Test
+  public void testWithWorkflowStates() {
+    ChannelState state = new ChannelState().withId("id").withState("state");
+    assertNull(state.getWorkflowStates());
+    state.withWorkflowStates(new ArrayList());
+    assertNotNull(state.getWorkflowStates());
+  }
+
+  @Test
+  public void testApplyDefaultIfNull() {
+    ChannelState state = new ChannelState();
+    assertNull(state.getWorkflowStates());
+
+    List<WorkflowState> s1 = state.applyDefaultIfNull();
+    List<WorkflowState> s2 = state.applyDefaultIfNull();
+    assertSame(s1, s2);
+    assertNotNull(state.getWorkflowStates());
+  }
+}


### PR DESCRIPTION
## Motivation

The default reply form health-check is 
```
{
    "java.util.Collection": [
        {}
    ]
}
```
Which means that we are exposing some internals to the outside world. It also might not help if we're trying to JSON path the things.

## Modification

- Added a new AdapterList object that can wrap the list of adapterStates (this is a list).
- Extracted common members into a State parent.
- Change WorkflowRestConsumer so that it now takes a "Content-Type" method when doing the response; the default is `text/plain`
- Minor refactor of health-check so that we have less complex branches, however this doesn't improve coverage for the "channel section" (it was 1/4 branches missed, now it's still 1/2).
- Default internal lists to be "null" so that they are not emitted as an empty array if they're null; they're just not ommited.
- Add tests.

## Result

The default JSON is now something like : 
```
{
    "adapters": [
        {
            "adapter-state": {
                "id": "MyInterlokInstance",
                "state": "StartedState"
            }
        }
    ]
}
```

## Testing

Build it and enable it; and then do a curl to the healthcheck; note that the Content-Type is now populated whereas previously it wasn't.

```
$ curl -si http://localhost:8080/health
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
Server: Jetty(9.4.28.v20200408)

{"adapters":[{"adapter-state":{"id":"MyInterlokInstance","state":"StartedState","channel-states":[{"channel-state":{"id":"jetty","state":"StartedState","workflow-states":[{"workflow-state":[{"id":"sign-document","state":"StartedState"},{"id":"verify-document","state":"StartedState"}]}]}}]}}]}
```