### PR TITLE
INTERLOK-3260 liveness readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,53 +20,74 @@ Optionally, you can also set the property named __rest.health-check.path__, whic
 
 ### Running
 
+There are 3 modes of operation a health-check, a liveness probe and a readiness probe.
 
-Using your favourite HTTP GET/POST tool, make a GET request to the running Interlok instance;
-```
-http GET http://<host>:<port>/workflow-health-check
-```
+#### Liveness probe
 
-This will return a JSON array, with all of your adapter, channel and workflow states.  A state, can be one of either; __StartedState__, __InitialisedState__, __StoppedState__ or __ClosedState__.
-
-You can further narrow the results of this service, by optionally specifying the adapter instance, channel and further even the workflow on the URL.  Like this;
 ```
-http GET http://<host>:<port>/workflow-health-check/<adapter-id>/<channel-id>/<workflow-id>
+curl -si http://localhost:8080/workflow-health-check/alive
 ```
 
-Below is an example of the resulting JSON.
+This just returns a `200 OK`, indicating that the Interlok instance considers itself _alive_. There is no response data.
+
+#### Readiness probe
+
+```
+curl -si http://localhost:8080/workflow-health-check/alive
+```
+
+This returns a `200 OK` if all the channels and workflows are started; otherwise a `503 Unavailable` is returned. There is no response data.
+
+#### HealthCheck mode
+
+```
+curl -si http://localhost:8080/workflow-health-check
+```
+
+This will return a JSON array, with all of your adapter, channel and workflow states.  A state, can be one of either; __StartedState__, __InitialisedState__, __StoppedState__ or __ClosedState__. For example:
 
 ```json
 {
-  "java.util.Collection": [
-    {
-      "adapter-state": {
-        "id": "MyInterlokInstance",
-        "state": "StartedState",
-        "channel-states": [
-          {
-            "channel-state": {
-              "id": "http_channel",
-              "state": "StartedState",
-              "workflow-states": [
-                {
-                  "workflow-state": [
-                    {
-                      "id": "secondStandardWorkflow",
-                      "state": "StartedState"
-                    },
-                    {
-                      "id": "standardWorkflow",
-                      "state": "StartedState"
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ]
+    "adapters": [{
+        "adapter-state": {
+            "id": "MyInterlokInstance",
+            "state": "StartedState",
+            "channel-states": [{
+                "channel-state": [{
+                    "id": "jetty1",
+                    "state": "StartedState",
+                    "workflow-states": [{
+                        "workflow-state": {
+                            "id": "jetty-workflow",
+                            "state": "StartedState"
+                        }
+                        "workflow-state": {
+                            "id": "another-workflow",
+                            "state": "StartedState"
+                        }
+                    }]
+                }, {
+                    "id": "jetty2(not-started)",
+                    "state": "ClosedState",
+                    "workflow-states": [{
+                        "workflow-state": {
+                            "id": "jetty-workflow",
+                            "state": "ClosedState"
+                        }
+                    }]
+                }, {
+                    "id": "jetty3",
+                    "state": "StartedState",
+                    "workflow-states": [{
+                        "workflow-state": {
+                            "id": "jetty-workflow",
+                            "state": "StartedState"
+                        }
+                    }]
+                }]
+            }]
+        }
+    }]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,26 +22,16 @@ Optionally, you can also set the property named __rest.health-check.path__, whic
 
 There are 3 modes of operation a health-check, a liveness probe and a readiness probe.
 
-#### Liveness probe
-
-```
-curl -si http://localhost:8080/workflow-health-check/alive
-```
-
-This just returns a `200 OK`, indicating that the Interlok instance considers itself _alive_. There is no response data in the event of a `200 OK`.
-
-#### Readiness probe
-
-```
-curl -si http://localhost:8080/workflow-health-check/alive
-```
-
-This returns a `200 OK` if all the channels and workflows are started; otherwise a `503 Unavailable` is returned. There is no response data in the event of a `200 OK`.
-
 #### HealthCheck mode
 
 ```
 curl -si http://localhost:8080/workflow-health-check
+HTTP/1.1 200 OK
+Content-Type: application/json
+Transfer-Encoding: chunked
+Server: Jetty(9.4.29.v20200521)
+
+{"adapters":[{"adapter-state":{"id":"MyInterlokInstance","state":"StartedState","channel-states":[{"channel-state":[{"id":"jetty1","state":"StartedState","workflow-states":[{"workflow-state":{"id":"jetty-workflow","state":"StartedState"}}]},{"id":"jetty2(not-started)","state":"ClosedState","workflow-states":[{"workflow-state":{"id":"jetty-workflow","state":"ClosedState"}}]},{"id":"jetty3","state":"StartedState","workflow-states":[{"workflow-state":{"id":"jetty-workflow","state":"StartedState"}}]}]}]}}]}
 ```
 
 This will return a JSON array, with all of your adapter, channel and workflow states.  A state, can be one of either; __StartedState__, __InitialisedState__, __StoppedState__ or __ClosedState__. For example:
@@ -90,6 +80,40 @@ This will return a JSON array, with all of your adapter, channel and workflow st
     }]
 }
 ```
+
+
+#### Liveness probe
+
+* From _3.10.2_
+
+```
+$ curl -si http://localhost:8080/workflow-health-check/alive
+HTTP/1.1 200 OK
+Content-Type: application/json
+Transfer-Encoding: chunked
+Server: Jetty(9.4.29.v20200521)
+
+
+```
+
+This just returns a `200 OK`, indicating that the Interlok instance considers itself _alive_. __Alive does not mean useful__. There is no response data in the event of a `200 OK`.
+
+#### Readiness probe
+
+* From _3.10.2_
+
+```
+$ curl -si http://localhost:8080/workflow-health-check/ready
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+Transfer-Encoding: chunked
+Server: Jetty(9.4.29.v20200521)
+
+{"failure": "jetty2(not-started) is not started"}
+```
+
+This returns a `200 OK` if all the channels and workflows are started; otherwise a `503 Unavailable` is returned. There is no response data in the event of a `200 OK`; in the event of a `503 Unavailable` only the first component that was "not-started" will be reported to shortcut response times.
+
 
 ## Cluster Manager
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are 3 modes of operation a health-check, a liveness probe and a readiness 
 curl -si http://localhost:8080/workflow-health-check/alive
 ```
 
-This just returns a `200 OK`, indicating that the Interlok instance considers itself _alive_. There is no response data.
+This just returns a `200 OK`, indicating that the Interlok instance considers itself _alive_. There is no response data in the event of a `200 OK`.
 
 #### Readiness probe
 
@@ -36,7 +36,7 @@ This just returns a `200 OK`, indicating that the Interlok instance considers it
 curl -si http://localhost:8080/workflow-health-check/alive
 ```
 
-This returns a `200 OK` if all the channels and workflows are started; otherwise a `503 Unavailable` is returned. There is no response data.
+This returns a `200 OK` if all the channels and workflows are started; otherwise a `503 Unavailable` is returned. There is no response data in the event of a `200 OK`.
 
 #### HealthCheck mode
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ ext {
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion="1.7.30"
   log4j2Version = '2.13.3'
+  mockitoVersion = '3.3.3'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {
@@ -152,7 +153,8 @@ dependencies {
 
   testCompile ('junit:junit:4.13')
   testCompile ("com.adaptris:interlok-stubs:$interlokCoreVersion") { changing=true }
-  testCompile ("org.mockito:mockito-all:1.10.19")
+  testCompile ("org.mockito:mockito-core:$mockitoVersion")
+  testCompile ("org.mockito:mockito-inline:$mockitoVersion")
   testCompile ("org.awaitility:awaitility:4.0.3")
   // INTERLOK-3233 we still need log4j since we're doing MDC stuffs.
   testCompile ("org.apache.logging.log4j:log4j-core:$log4j2Version")

--- a/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
+++ b/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
@@ -1,27 +1,32 @@
 package com.adaptris.rest;
 
 import java.util.Properties;
+import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.management.MgmtComponentImpl;
 import com.adaptris.core.util.LifecycleHelper;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
 public abstract class AbstractRestfulEndpoint extends MgmtComponentImpl implements AdaptrisMessageListener {
   public static final String MDC_KEY = "ManagementComponent";
 
-  @Getter
-  @Setter
+  @Getter(AccessLevel.PACKAGE)
+  @Setter(AccessLevel.PACKAGE)
   private transient WorkflowServicesConsumer consumer;
 
+  @Setter(AccessLevel.PROTECTED)
+  @Getter(AccessLevel.PROTECTED)
+  private String configuredUrlPath;
+
   public AbstractRestfulEndpoint() {
-    this.setConsumer(new HttpRestWorkflowServicesConsumer(friendlyName()));
+    setConsumer(new HttpRestWorkflowServicesConsumer(friendlyName()));
   }
-  
+
   @Override
-  public void init(Properties config) throws Exception {
-  }
+  public void init(Properties config) throws Exception {}
 
   @Override
   public void start() throws Exception {
@@ -29,7 +34,7 @@ public abstract class AbstractRestfulEndpoint extends MgmtComponentImpl implemen
     new Thread(() -> {
       try {
         getConsumer().setAcceptedHttpMethods(getAcceptedFilter());
-        getConsumer().setConsumedUrlPath(getConfiguredUrlPath());
+        getConsumer().setConsumedUrlPath(configuredUrlPath());
         getConsumer().setMessageListener(instance);
         LifecycleHelper.initAndStart(getConsumer());
 
@@ -39,11 +44,15 @@ public abstract class AbstractRestfulEndpoint extends MgmtComponentImpl implemen
       }
     }).start();
   }
-  
+
   protected abstract String getAcceptedFilter();
-  
-  protected abstract String getConfiguredUrlPath();
-  
+
+  protected abstract String getDefaultUrlPath();
+
+  protected String configuredUrlPath() {
+    return ObjectUtils.defaultIfNull(getConfiguredUrlPath(), getDefaultUrlPath());
+  }
+
   @Override
   public String friendlyName() {
     return this.getClass().getSimpleName();

--- a/src/main/java/com/adaptris/rest/ClusterManagerComponent.java
+++ b/src/main/java/com/adaptris/rest/ClusterManagerComponent.java
@@ -1,6 +1,5 @@
 package com.adaptris.rest;
-
-import static com.adaptris.rest.WorkflowServicesConsumer.sendErrorResponseQuietly;
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -61,7 +60,7 @@ public class ClusterManagerComponent extends AbstractRestfulEndpoint {
       onSuccess.accept(message);
 
     } catch (Exception ex) {
-      sendErrorResponseQuietly(getConsumer(), message, ex);
+      getConsumer().doErrorResponse(message, ex, ERROR_DEFAULT);
     } finally {
       MDC.remove(MDC_KEY);
     }

--- a/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
@@ -11,7 +11,6 @@ import org.slf4j.MDC;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.ConfiguredConsumeDestination;
-import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.http.jetty.EmbeddedConnection;
 import com.adaptris.core.http.jetty.JettyConstants;
@@ -22,16 +21,18 @@ import com.adaptris.core.http.jetty.MetadataParameterHandler;
 import com.adaptris.core.http.jetty.NoOpResponseHeaderProvider;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
-  
+
   private static final String METADATA_STATUS = "httpReplyStatus";
   private static final String METADATA_CONTENT_TYPE = "httpReplyContentType";
 
   private static final String HEADER_PREFIX = "http.header.";
-  
+
   private static final String PARAMETER_PREFIX = "http.param.";
-  
+
   @Getter
   @Setter
   private transient JettyResponseService responseService;
@@ -46,9 +47,9 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
 
   @Override
   protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
-    this.setResponseService(new JettyResponseService().withResponseHeaderProvider(new NoOpResponseHeaderProvider())
+    setResponseService(new JettyResponseService().withResponseHeaderProvider(new NoOpResponseHeaderProvider())
         .withHttpStatus("%message{httpReplyStatus}").withContentType("%message{httpReplyContentType}"));
-    
+
     EmbeddedConnection jettyConnection = new EmbeddedConnection();
     JettyMessageConsumer messageConsumer = new JettyMessageConsumer() {
       @Override
@@ -58,33 +59,36 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
         return super.createMessage(request, response);
       }
     };
-    
+
     ConfiguredConsumeDestination configuredConsumeDestination = new ConfiguredConsumeDestination(consumedUrlPath);
     configuredConsumeDestination.setFilterExpression(acceptedHttpMethods);
-    
+
     messageConsumer.setDestination(configuredConsumeDestination);
     messageConsumer.setHeaderHandler(new MetadataHeaderHandler(HEADER_PREFIX));
     messageConsumer.setParameterHandler(new MetadataParameterHandler(PARAMETER_PREFIX));
     messageConsumer.registerAdaptrisMessageListener(messageListener);
-    
+
     return new StandaloneConsumer(jettyConnection, messageConsumer);
   }
 
   @Override
-  protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage, String contentType)
-      throws ServiceException {
-    processedMessage.addObjectHeader(JettyConstants.JETTY_WRAPPER, originalMessage.getObjectHeaders().get(JettyConstants.JETTY_WRAPPER));
-    processedMessage.addMetadata(METADATA_STATUS, String.valueOf(OK_200));
-    processedMessage.addMetadata(METADATA_CONTENT_TYPE, StringUtils.defaultIfBlank(contentType, CONTENT_TYPE_DEFAULT));
-    this.getResponseService().doService(processedMessage);
+  protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
+      String contentType, int httpStatus) {
+    try {
+      processedMessage.addObjectHeader(JettyConstants.JETTY_WRAPPER,
+          originalMessage.getObjectHeaders().get(JettyConstants.JETTY_WRAPPER));
+      processedMessage.addMetadata(METADATA_STATUS, String.valueOf(httpStatus));
+      processedMessage.addMetadata(METADATA_CONTENT_TYPE,
+          StringUtils.defaultIfBlank(contentType, CONTENT_TYPE_DEFAULT));
+      getResponseService().doService(processedMessage);
+    } catch (Exception exc) {
+      log.trace("Ignored exception during error response {}", exc.getMessage());
+    }
   }
 
   @Override
-  public void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus)
-      throws ServiceException {
+  public void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus) {
     message.setContent(ExceptionUtils.getStackTrace(e), message.getContentEncoding());
-    message.addMetadata(METADATA_STATUS, String.valueOf(httpStatus));
-    message.addMetadata(METADATA_CONTENT_TYPE, CONTENT_TYPE_DEFAULT);
-    this.getResponseService().doService(message);
+    doResponse(message, message, CONTENT_TYPE_DEFAULT, httpStatus);
   }
 }

--- a/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
@@ -83,7 +83,7 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
           StringUtils.defaultIfBlank(contentType, CONTENT_TYPE_DEFAULT));
       getResponseService().doService(processedMessage);
     } catch (Exception exc) {
-      log.trace("Ignored exception during error response {}", exc.getMessage());
+      log.trace("Ignored exception sending HTTP response {}", exc.getMessage());
     }
   }
 

--- a/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
@@ -24,11 +24,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
-
-
-  private static final String OK_200 = "200";
-  
-  private static final String ERROR_400 = "400";
   
   private static final String METADATA_STATUS = "httpReplyStatus";
   private static final String METADATA_CONTENT_TYPE = "httpReplyContentType";
@@ -79,16 +74,17 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
   protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage, String contentType)
       throws ServiceException {
     processedMessage.addObjectHeader(JettyConstants.JETTY_WRAPPER, originalMessage.getObjectHeaders().get(JettyConstants.JETTY_WRAPPER));
-    processedMessage.addMetadata(METADATA_STATUS, OK_200);
+    processedMessage.addMetadata(METADATA_STATUS, String.valueOf(OK_200));
     processedMessage.addMetadata(METADATA_CONTENT_TYPE, StringUtils.defaultIfBlank(contentType, CONTENT_TYPE_DEFAULT));
     this.getResponseService().doService(processedMessage);
   }
 
   @Override
-  public void doErrorResponse(AdaptrisMessage message, Exception e, String contentType) throws ServiceException {
+  public void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus)
+      throws ServiceException {
     message.setContent(ExceptionUtils.getStackTrace(e), message.getContentEncoding());
-    message.addMetadata(METADATA_STATUS, ERROR_400);
-    message.addMetadata(METADATA_CONTENT_TYPE, StringUtils.defaultIfBlank(contentType, CONTENT_TYPE_DEFAULT));
+    message.addMetadata(METADATA_STATUS, String.valueOf(httpStatus));
+    message.addMetadata(METADATA_CONTENT_TYPE, CONTENT_TYPE_DEFAULT);
     this.getResponseService().doService(message);
   }
 }

--- a/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
@@ -19,6 +19,7 @@ import com.adaptris.core.http.jetty.JettyResponseService;
 import com.adaptris.core.http.jetty.MetadataHeaderHandler;
 import com.adaptris.core.http.jetty.MetadataParameterHandler;
 import com.adaptris.core.http.jetty.NoOpResponseHeaderProvider;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -33,12 +34,12 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
 
   private static final String PARAMETER_PREFIX = "http.param.";
 
-  @Getter
-  @Setter
+  @Getter(AccessLevel.PACKAGE)
+  @Setter(AccessLevel.PACKAGE)
   private transient JettyResponseService responseService;
 
-  @Getter
-  @Setter
+  @Getter(AccessLevel.PRIVATE)
+  @Setter(AccessLevel.PRIVATE)
   private transient String owner;
 
   public HttpRestWorkflowServicesConsumer(String ownerRef) {
@@ -55,7 +56,7 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
       @Override
       public AdaptrisMessage createMessage(HttpServletRequest request, HttpServletResponse response)
           throws IOException, ServletException {
-        MDC.put(MDC_KEY, owner);
+        MDC.put(MDC_KEY, getOwner());
         return super.createMessage(request, response);
       }
     };

--- a/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
+++ b/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
@@ -1,6 +1,6 @@
 package com.adaptris.rest;
 
-import static com.adaptris.rest.WorkflowServicesConsumer.sendErrorResponseQuietly;
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
@@ -110,7 +110,7 @@ public class WorkflowServicesComponent extends AbstractRestfulEndpoint {
 
     } catch (Exception e) {
       log.error("Unable to inject REST message into the workflow.", e);
-      sendErrorResponseQuietly(getConsumer(), message, e);
+      getConsumer().doErrorResponse(message, e, ERROR_DEFAULT);
     } finally {
       MDC.remove(MDC_KEY);
     }

--- a/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
@@ -9,13 +9,10 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.interlok.util.Args;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @NoArgsConstructor
 public abstract class WorkflowServicesConsumer implements ComponentLifecycle, ComponentLifecycleExtension {
 
@@ -57,11 +54,15 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
     doResponse(original, processed, CONTENT_TYPE_DEFAULT);
   }
 
-  protected abstract void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage, String contentType)
-      throws ServiceException;
+  protected void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType)
+      throws ServiceException {
+    doResponse(orig, proc, contentType, OK_200);
+  }
 
-  protected abstract void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus)
-      throws ServiceException;
+  protected abstract void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType,
+      int httpResponse);
+
+  protected abstract void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus);
 
   @Override
   public void prepare() throws CoreException {
@@ -87,18 +88,5 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
   @Override
   public void close() {
     LifecycleHelper.close(getStandaloneConsumer());
-  }
-
-  public static void sendErrorResponseQuietly(WorkflowServicesConsumer c, AdaptrisMessage msg,
-      Exception e, int httpStatus) {
-    try {
-      Args.notNull(c, "workflow-services-consumer").doErrorResponse(msg, e, httpStatus);
-    } catch (Exception exc) {
-      log.trace("Ignored exception during error response {}", exc.getMessage());
-    }
-  }
-
-  public static void sendErrorResponseQuietly(WorkflowServicesConsumer c, AdaptrisMessage msg, Exception e) {
-    sendErrorResponseQuietly(c, msg, e, ERROR_DEFAULT);
   }
 }

--- a/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
+++ b/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
@@ -1,5 +1,6 @@
 package com.adaptris.rest;
 
+import java.net.HttpURLConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.ComponentLifecycle;
@@ -19,17 +20,21 @@ import lombok.extern.slf4j.Slf4j;
 public abstract class WorkflowServicesConsumer implements ComponentLifecycle, ComponentLifecycleExtension {
 
 
+  public static final int OK_200 = HttpURLConnection.HTTP_OK;
+  public static final int ERROR_DEFAULT = HttpURLConnection.HTTP_INTERNAL_ERROR;
+  public static final int ERROR_NOT_READY = HttpURLConnection.HTTP_UNAVAILABLE;
+
   public static final String CONTENT_TYPE_DEFAULT = "text/plain";
   public static final String CONTENT_TYPE_JSON = "application/json";
 
   @Getter
   @Setter
   private StandaloneConsumer standaloneConsumer;
-  
+
   @Getter
   @Setter
   private AdaptrisMessageListener messageListener;
-  
+
   /**
    * This is the url that this consumer will listen for requests.
    * For example "/workflow-services/*"; will trigger this consumer for any requests on "http://host:port/workflow-services/...".
@@ -37,7 +42,7 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
   @Getter
   @Setter
   private String consumedUrlPath;
-  
+
   /**
    * A comma separated list of accepted http request methods; GET, POST, PATCH etc etc
    * And example might be "GET,POST".
@@ -45,24 +50,25 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
   @Getter
   @Setter
   private String acceptedHttpMethods;
-    
+
   protected abstract StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods);
-  
+
   protected void doResponse(AdaptrisMessage original, AdaptrisMessage processed) throws ServiceException {
     doResponse(original, processed, CONTENT_TYPE_DEFAULT);
   }
 
   protected abstract void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage, String contentType)
       throws ServiceException;
-  
-  public abstract void doErrorResponse(AdaptrisMessage message, Exception e, String contentType) throws ServiceException;
+
+  protected abstract void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus)
+      throws ServiceException;
 
   @Override
   public void prepare() throws CoreException {
-    this.setStandaloneConsumer(configureConsumer(this.getMessageListener(), this.getConsumedUrlPath(), this.getAcceptedHttpMethods()));
+    setStandaloneConsumer(configureConsumer(getMessageListener(), getConsumedUrlPath(), getAcceptedHttpMethods()));
     LifecycleHelper.prepare(getStandaloneConsumer());
   }
-  
+
   @Override
   public void init() throws CoreException {
     LifecycleHelper.init(getStandaloneConsumer());
@@ -82,16 +88,17 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
   public void close() {
     LifecycleHelper.close(getStandaloneConsumer());
   }
-  
-  public static void sendErrorResponseQuietly(WorkflowServicesConsumer c, AdaptrisMessage msg, Exception e, String contentType) {
+
+  public static void sendErrorResponseQuietly(WorkflowServicesConsumer c, AdaptrisMessage msg,
+      Exception e, int httpStatus) {
     try {
-      Args.notNull(c, "workflow-services-consumer").doErrorResponse(msg, e, contentType);
+      Args.notNull(c, "workflow-services-consumer").doErrorResponse(msg, e, httpStatus);
     } catch (Exception exc) {
       log.trace("Ignored exception during error response {}", exc.getMessage());
     }
   }
 
   public static void sendErrorResponseQuietly(WorkflowServicesConsumer c, AdaptrisMessage msg, Exception e) {
-    sendErrorResponseQuietly(c, msg, e, CONTENT_TYPE_DEFAULT);
+    sendErrorResponseQuietly(c, msg, e, ERROR_DEFAULT);
   }
 }

--- a/src/main/java/com/adaptris/rest/util/JmxMBeanHelper.java
+++ b/src/main/java/com/adaptris/rest/util/JmxMBeanHelper.java
@@ -1,55 +1,53 @@
 package com.adaptris.rest.util;
 
 import java.util.Set;
-
 import javax.management.JMX;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
-
 import com.adaptris.core.util.JmxHelper;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Synchronized;
 
+@NoArgsConstructor
 public class JmxMBeanHelper {
 
+  @Getter(AccessLevel.PRIVATE)
+  @Setter(AccessLevel.PRIVATE)
   private MBeanServer mBeanServer;
-  
-  public JmxMBeanHelper() {
-  }
-  
+
+  private transient final Object mbeanLock = new Object[0];
+
   public String getStringAttribute(String objectName, String attributeName) throws Exception {
     return (String) mBeanServer().getAttribute(new ObjectName(objectName), attributeName);
   }
-  
+
   public String getStringAttributeClassName(String objectName, String attributeName) throws Exception {
-    return (String) mBeanServer().getAttribute(new ObjectName(objectName), attributeName).getClass().getSimpleName();
+    return mBeanServer().getAttribute(new ObjectName(objectName), attributeName).getClass().getSimpleName();
   }
-  
+
   public <T> T proxyMBean(String objectNameString, Class<T> type) throws MalformedObjectNameException {
-    return (T) JMX.newMBeanProxy(mBeanServer(), new ObjectName(objectNameString), type, true);
+    return JMX.newMBeanProxy(mBeanServer(), new ObjectName(objectNameString), type, true);
   }
-  
+
   @SuppressWarnings("unchecked")
   public Set<ObjectName> getObjectSetAttribute(String objectName, String attributeName) throws Exception {
     return (Set<ObjectName>) mBeanServer().getAttribute(new ObjectName(objectName), attributeName);
   }
-  
+
   public Set<ObjectInstance> getMBeans(String objectNameQuery) throws Exception {
     return mBeanServer().queryMBeans(new ObjectName(objectNameQuery), null);
   }
 
+  @Synchronized("mbeanLock")
   protected MBeanServer mBeanServer() {
-    if(getmBeanServer() == null)
-      this.setmBeanServer(JmxHelper.findMBeanServer());
-    
-    return this.getmBeanServer();
-  }
-  
-  public MBeanServer getmBeanServer() {
-    return mBeanServer;
-  }
+    if(getMBeanServer() == null)
+      setMBeanServer(JmxHelper.findMBeanServer());
 
-  public void setmBeanServer(MBeanServer mBeanServer) {
-    this.mBeanServer = mBeanServer;
+    return getMBeanServer();
   }
 }

--- a/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
+++ b/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
@@ -172,7 +172,8 @@ public class ClusterManagerComponentTest {
 
 
     @Override
-    public void doErrorResponse(AdaptrisMessage message, Exception e, String contentType) throws ServiceException {
+    public void doErrorResponse(AdaptrisMessage message, Exception e, int status)
+        throws ServiceException {
       isError = true;
     }
     

--- a/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
+++ b/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
@@ -18,7 +18,6 @@ import org.mockito.MockitoAnnotations;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.cache.ExpiringMapCache;
@@ -27,50 +26,50 @@ import com.adaptris.mgmt.cluster.mbean.ClusterManagerMBean;
 import com.adaptris.rest.util.JmxMBeanHelper;
 
 public class ClusterManagerComponentTest {
-  
+
   private static final String CLUSTER_MANAGER_OBJECT_NAME = "com.adaptris:type=ClusterManager,id=ClusterManager";
-  
+
   private ClusterManagerComponent clusterManagerComponent;
-  
+
   private TestConsumer testConsumer = new TestConsumer();
-  
+
   private ExpiringMapCache expiringMapCache;
-  
+
   private ClusterInstance clusterInstanceOne;
-  
+
   private ClusterInstance clusterInstanceTwo;
-  
+
   private AdaptrisMessage message;
-  
+
   @Mock private JmxMBeanHelper mockJmxHelper;
-  
+
   @Mock private ClusterManagerMBean mockClusterManagerMBean;
-  
+
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    
+
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
+
     clusterManagerComponent = new ClusterManagerComponent();
     clusterManagerComponent.setJmxMBeanHelper(mockJmxHelper);
     clusterManagerComponent.setConsumer(testConsumer);
-    
+
     clusterManagerComponent.init(new Properties());
     clusterManagerComponent.start();
-    
+
     expiringMapCache = new ExpiringMapCache();
     expiringMapCache.init();
-    
+
     clusterInstanceOne = new ClusterInstance(UUID.randomUUID(), "id-1", "jms-address-1");
     clusterInstanceTwo = new ClusterInstance(UUID.randomUUID(), "id-2", "jms-address-2");
-    
+
     when(mockJmxHelper.proxyMBean(CLUSTER_MANAGER_OBJECT_NAME, ClusterManagerMBean.class))
         .thenReturn(mockClusterManagerMBean);
     when(mockClusterManagerMBean.getClusterInstances())
         .thenReturn(expiringMapCache);
   }
-  
+
   @After
   public void tearDown() throws Exception {
     clusterManagerComponent.stop();
@@ -80,84 +79,85 @@ public class ClusterManagerComponentTest {
   @Test
   public void testNoClusters() throws Exception {
     clusterManagerComponent.onAdaptrisMessage(message);
-    
+
     await()
       .atMost(Durations.FIVE_SECONDS)
     .with()
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
-  
+
     // assert no cluster instances;
     assertFalse(testConsumer.payload.contains("instance"));
   }
-  
+
   @Test
   public void testMyOwnClusterInstance() throws Exception {
     expiringMapCache.put(clusterInstanceOne.getUniqueId(), clusterInstanceOne);
-    
+
     clusterManagerComponent.onAdaptrisMessage(message);
-    
+
     await()
       .atMost(Durations.FIVE_SECONDS)
     .with()
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
-  
+
     @SuppressWarnings("unchecked")
     List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
-    
+
     assertTrue(instances.size() == 1);
     assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
     assertTrue(instances.get(0).getClusterUuid().equals(clusterInstanceOne.getClusterUuid()));
     assertTrue(instances.get(0).getJmxAddress().equals(clusterInstanceOne.getJmxAddress()));
   }
-  
+
   @Test
   public void testMultipleClusterInstances() throws Exception {
     expiringMapCache.put(clusterInstanceOne.getUniqueId(), clusterInstanceOne);
     expiringMapCache.put(clusterInstanceTwo.getUniqueId(), clusterInstanceTwo);
-    
+
     clusterManagerComponent.onAdaptrisMessage(message);
-    
+
     await()
       .atMost(Durations.FIVE_SECONDS)
     .with()
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
-  
+
     @SuppressWarnings("unchecked")
     List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
-    
+
     assertTrue(instances.size() == 2);
     assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
     assertTrue(instances.get(0).getClusterUuid().equals(clusterInstanceOne.getClusterUuid()));
     assertTrue(instances.get(0).getJmxAddress().equals(clusterInstanceOne.getJmxAddress()));
-    
+
     assertTrue(instances.get(1).getUniqueId().equals(clusterInstanceTwo.getUniqueId()));
     assertTrue(instances.get(1).getClusterUuid().equals(clusterInstanceTwo.getClusterUuid()));
     assertTrue(instances.get(1).getJmxAddress().equals(clusterInstanceTwo.getJmxAddress()));
   }
-  
+
   @Test
   public void testMBeansNotAvailable() throws Exception {
     doThrow(new MalformedObjectNameException("expected"))
         .when(mockJmxHelper).proxyMBean(CLUSTER_MANAGER_OBJECT_NAME, ClusterManagerMBean.class);
-        
+
     clusterManagerComponent.onAdaptrisMessage(message);
-    
+
     await()
       .atMost(Durations.FIVE_SECONDS)
     .with()
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
-  
+
     assertTrue(testConsumer.isError);
   }
-  
+
   class TestConsumer extends WorkflowServicesConsumer {
-    
+
     String payload;
     boolean isError;
+    int httpStatus = -1;
 
     @Override
     protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
@@ -165,25 +165,26 @@ public class ClusterManagerComponentTest {
     }
 
     @Override
-    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage, String contentType)
-        throws ServiceException {
+    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
+        String contentType, int status) {
       payload = processedMessage.getContent();
+      httpStatus = status;
     }
 
 
     @Override
-    public void doErrorResponse(AdaptrisMessage message, Exception e, int status)
-        throws ServiceException {
+    public void doErrorResponse(AdaptrisMessage message, Exception e, int status) {
       isError = true;
+      httpStatus = status;
     }
-    
+
     public boolean complete() {
       return isError == true || payload != null;
     }
-    
+
     @Override
     public void prepare() {
-      
+
     }
   }
 }

--- a/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
@@ -67,7 +67,8 @@ public class HttpRestWorkflowServicesConsumerTest {
   @Test
   public void testErrorResponse() throws Exception {
     servicesConsumer.setResponseService(mockResponseService);
-    servicesConsumer.doErrorResponse(originalMessage, new Exception(), null);
+    servicesConsumer.doErrorResponse(originalMessage, new Exception(),
+        WorkflowServicesConsumer.ERROR_DEFAULT);
 
     verify(mockResponseService).doService(originalMessage);
   }

--- a/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/HttpRestWorkflowServicesConsumerTest.java
@@ -1,6 +1,9 @@
 package com.adaptris.rest;
 
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import org.junit.After;
 import org.junit.Before;
@@ -10,6 +13,7 @@ import org.mockito.MockitoAnnotations;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.http.jetty.JettyResponseService;
 
@@ -65,11 +69,25 @@ public class HttpRestWorkflowServicesConsumerTest {
   }
 
   @Test
+  public void testOkResponse_Throws() throws Exception {
+    servicesConsumer.setResponseService(mockResponseService);
+    doThrow(new ServiceException()).when(mockResponseService).doService(any());
+    servicesConsumer.doResponse(originalMessage, processedMessage);
+  }
+
+
+  @Test
   public void testErrorResponse() throws Exception {
     servicesConsumer.setResponseService(mockResponseService);
-    servicesConsumer.doErrorResponse(originalMessage, new Exception(),
-        WorkflowServicesConsumer.ERROR_DEFAULT);
-
+    servicesConsumer.doErrorResponse(originalMessage, new Exception(), ERROR_DEFAULT);
     verify(mockResponseService).doService(originalMessage);
+  }
+
+
+  @Test
+  public void testErrorResponse_Throws() throws Exception {
+    servicesConsumer.setResponseService(mockResponseService);
+    doThrow(new ServiceException()).when(mockResponseService).doService(any());
+    servicesConsumer.doErrorResponse(originalMessage, new Exception(), ERROR_DEFAULT);
   }
 }

--- a/src/test/java/com/adaptris/rest/WorkflowHealthCheckComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowHealthCheckComponentTest.java
@@ -4,259 +4,346 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
+import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Durations;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.AdaptrisMessageListener;
-import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.InitialisedState;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StartedState;
 import com.adaptris.core.StoppedState;
+import com.adaptris.core.XStreamJsonMarshaller;
+import com.adaptris.core.http.jetty.JettyConstants;
 import com.adaptris.core.runtime.AdapterManager;
+import com.adaptris.rest.healthcheck.AdapterState;
 import com.adaptris.rest.util.JmxMBeanHelper;
 
 public class WorkflowHealthCheckComponentTest {
-  
+
   private static final String ADAPTER_ID = "MyAdapterId";
-  
   private static final String CHANNEL_ID = "MyChannelId";
-  
   private static final String WORKFLOW_ID1 = "MyWorkflowId1";
-  
   private static final String WORKFLOW_ID2 = "MyWorkflowId2";
-  
   private static final String UNIQUE_ID = "UniqueId";
-
   private static final String CHILDREN_ATTRIBUTE = "Children";
-
   private static final String COMPONENT_STATE = "ComponentState";
-  
   private static final String CHANNEL_OBJECT_NAME = "com.adaptris:type=Channel,adapter=" + ADAPTER_ID + ",id=" + CHANNEL_ID;
-  
   private static final String WORKFLOW_OBJECT_NAME_1 = "com.adaptris:type=Workflow,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + WORKFLOW_ID1;
-  
   private static final String WORKFLOW_OBJECT_NAME_2 = "com.adaptris:type=Channel,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + WORKFLOW_ID2;
-  
-  private static final String PATH_KEY = "jettyURI";
-  
-  private WorkflowHealthCheckComponent healthCheck;
-  
-  private Set<ObjectInstance> adapterInstances;
-  
-  private Set<ObjectName> channelObjectNames;
-  
-  private ObjectName channelObjectName;
-  
-  private Set<ObjectName> workflowObjectNames;
-  
-  private AdaptrisMessage message;
-  
-  private ObjectName workflowObjectName1, workflowObjectName2;
-  
-  private TestConsumer testConsumer;
-  
-  private ObjectName adapterObjectName;
-  
-  @Mock private JmxMBeanHelper mockJmxHelper;
-  
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    
-    message = DefaultMessageFactory.getDefaultInstance().newMessage();
-    
-    adapterObjectName = new ObjectName("com.adaptris:type=Adapter,id=" + ADAPTER_ID);
-    ObjectInstance adapterInstance = new ObjectInstance(adapterObjectName, AdapterManager.class.getName());
-    adapterInstances = new HashSet<>();
-    adapterInstances.add(adapterInstance);
-    
-    channelObjectNames = new HashSet<>();
-    channelObjectName = new ObjectName(CHANNEL_OBJECT_NAME);
-    channelObjectNames.add(channelObjectName);
-    
-    workflowObjectNames = new HashSet<>();
-    workflowObjectName1 = new ObjectName(WORKFLOW_OBJECT_NAME_1);
-    workflowObjectName2 = new ObjectName(WORKFLOW_OBJECT_NAME_2);
-    workflowObjectNames.add(workflowObjectName1);
-    workflowObjectNames.add(workflowObjectName2);
-    
-    healthCheck = new WorkflowHealthCheckComponent();
-    
-    when(mockJmxHelper.getMBeans(any()))
-        .thenReturn(adapterInstances);
-    when(mockJmxHelper.getStringAttribute(adapterObjectName.toString(), UNIQUE_ID))
-        .thenReturn(ADAPTER_ID);
-    when(mockJmxHelper.getStringAttributeClassName(adapterObjectName.toString(), COMPONENT_STATE))
-        .thenReturn(StartedState.class.getSimpleName());
-    when(mockJmxHelper.getObjectSetAttribute(adapterObjectName.toString(), CHILDREN_ATTRIBUTE))
-        .thenReturn(channelObjectNames);
-    
-    when(mockJmxHelper.getStringAttribute(channelObjectName.toString(), UNIQUE_ID))
-        .thenReturn(CHANNEL_ID);
-    when(mockJmxHelper.getStringAttributeClassName(channelObjectName.toString(), COMPONENT_STATE))
-        .thenReturn(StartedState.class.getSimpleName());
-    when(mockJmxHelper.getObjectSetAttribute(channelObjectName.toString(), CHILDREN_ATTRIBUTE))
-        .thenReturn(workflowObjectNames);
-    
-    when(mockJmxHelper.getStringAttribute(workflowObjectName1.toString(), UNIQUE_ID))
-        .thenReturn(WORKFLOW_ID1);
-    when(mockJmxHelper.getStringAttributeClassName(workflowObjectName1.toString(), COMPONENT_STATE))
-        .thenReturn(InitialisedState.class.getSimpleName());
-    
-    when(mockJmxHelper.getStringAttribute(workflowObjectName2.toString(), UNIQUE_ID))
-        .thenReturn(WORKFLOW_ID2);
-    when(mockJmxHelper.getStringAttributeClassName(workflowObjectName2.toString(), COMPONENT_STATE))
-        .thenReturn(StoppedState.class.getSimpleName());
-    
-    testConsumer = new TestConsumer();
-    healthCheck.setConsumer(testConsumer);
-    
-    healthCheck.init(new Properties());
-    healthCheck.start();
+  private static final String PATH_KEY = JettyConstants.JETTY_URI;
+
+  @Test(expected = CoreException.class)
+  public void testMarshalling() throws Exception {
+    List<AdapterState> states = new ArrayList<>();
+    WorkflowHealthCheckComponent healthCheck = new WorkflowHealthCheckComponent();
+    assertFalse(StringUtils.isBlank(healthCheck.toString(states)));
+
+    XStreamJsonMarshaller mockMarshaller = Mockito.mock(XStreamJsonMarshaller.class);
+    doThrow(new CoreException("Expected")).when(mockMarshaller).marshal(any());
+    healthCheck.setMarshaller(mockMarshaller);
+
+    healthCheck.toString(states);
   }
-  
-  @After
-  public void tearDown() throws Exception {
-    healthCheck.stop();
-    healthCheck.destroy();
-  }
-  
+
   @Test
-  public void testNoMBeans() throws Exception {    
+  public void testNoMBeans() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
-    
-    doThrow(new Exception("Expected"))
-        .when(mockJmxHelper).getMBeans(any());
-    
-    healthCheck.onAdaptrisMessage(message);
-    
- // Wait for 5 seconds, Fail if we don't get the received message after that time.
-    await()
-      .atMost(Durations.FIVE_SECONDS)
-    .with()
-      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-      .until(testConsumer::complete);
-    
-    assertFalse(testConsumer.isError);
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+
+    when(mockJmxHelper.getMBeans(anyString())).thenReturn(Collections.EMPTY_SET);
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+
+      assertFalse(testConsumer.isError);
+    } finally {
+      wrapper.destroy();
+    }
   }
-  
+
   @Test
   public void testErrorFromMBean() throws Exception {
-    healthCheck.setJmxMBeanHelper(mockJmxHelper);
-    
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
-    
-    doThrow(new Exception("Expected"))
-        .when(mockJmxHelper).getMBeans(any());
-    
-    healthCheck.onAdaptrisMessage(message);
-    
- // Wait for 5 seconds, Fail if we don't get the received message after that time.
-    await()
-      .atMost(Durations.FIVE_SECONDS)
-    .with()
-      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-      .until(testConsumer::complete);
-    
-    assertTrue(testConsumer.isError);
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+
+    doThrow(new Exception("Expected")).when(mockJmxHelper).getMBeans(anyString());
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+
+      assertTrue(testConsumer.isError);
+      assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, testConsumer.httpStatus);
+    } finally {
+      wrapper.destroy();
+    }
   }
-  
+
   @Test
   public void testErrorFromMBeanAttribute() throws Exception {
-    healthCheck.setJmxMBeanHelper(mockJmxHelper);
-    
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
-    
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+
     doThrow(new Exception("Expected"))
-        .when(mockJmxHelper).getStringAttribute(any(), any());
-    
-    healthCheck.onAdaptrisMessage(message);
-    
- // Wait for 5 seconds, Fail if we don't get the received message after that time.
-    await()
-      .atMost(Durations.FIVE_SECONDS)
-    .with()
-      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-      .until(testConsumer::complete);
-    
-    assertTrue(testConsumer.isError);
+        .when(mockJmxHelper).getStringAttribute(anyString(), any());
+
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+
+      assertTrue(testConsumer.isError);
+      assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, testConsumer.httpStatus);
+
+    } finally {
+      wrapper.destroy();
+    }
   }
-  
+
+
   @Test
-  public void testWrongAdapterIdEmptyPayload() throws Exception {
-    healthCheck.setJmxMBeanHelper(mockJmxHelper);
-    message.addMessageHeader(PATH_KEY, "/workflow-health-check/does_not_exist");
-    
-    healthCheck.onAdaptrisMessage(message);
-    
- // Wait for 5 seconds, Fail if we don't get the received message after that time.
-    await()
-      .atMost(Durations.FIVE_SECONDS)
-    .with()
-      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-      .until(testConsumer::complete);
-    assertEquals("{\"adapters\":[\"\"]}", testConsumer.payload);
-  }
-  
-  @Test
-  public void testEverythingReturned() throws Exception {
-    healthCheck.setJmxMBeanHelper(mockJmxHelper);
+  public void testHealthCheck_AllStarted() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
-    
-    healthCheck.onAdaptrisMessage(message);
-    
- // Wait for 5 seconds, Fail if we don't get the received message after that time.
-    await()
-      .atMost(Durations.FIVE_SECONDS)
-    .with()
-      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-      .until(testConsumer::complete);
-    assertTrue(testConsumer.payload.contains(ADAPTER_ID));
-    assertTrue(testConsumer.payload.contains(CHANNEL_ID));
-    assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
-    assertTrue(testConsumer.payload.contains(WORKFLOW_ID2));
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+      assertFalse(testConsumer.isError);
+      assertTrue(testConsumer.payload.contains(ADAPTER_ID));
+      assertTrue(testConsumer.payload.contains(CHANNEL_ID));
+      assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
+      assertTrue(testConsumer.payload.contains(WORKFLOW_ID2));
+    } finally {
+      wrapper.destroy();
+    }
   }
-  
+
   @Test
-  public void testSpecificWorkflowReturned() throws Exception {
-    healthCheck.setJmxMBeanHelper(mockJmxHelper);
-    message.addMessageHeader(PATH_KEY, "/workflow-health-check/" + ADAPTER_ID + "/" + CHANNEL_ID + "/" + WORKFLOW_ID1);
-    
-    healthCheck.onAdaptrisMessage(message);
-    
- // Wait for 5 seconds, Fail if we don't get the received message after that time.
-    await()
-      .atMost(Durations.FIVE_SECONDS)
-    .with()
-      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-      .until(testConsumer::complete);
-    
-    assertTrue(testConsumer.payload.contains(ADAPTER_ID));
-    assertTrue(testConsumer.payload.contains(CHANNEL_ID));
-    assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
-    
-    assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
+  public void testHealthCheck_NotStarted() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+      assertFalse(testConsumer.isError);
+      assertTrue(testConsumer.payload.contains(ADAPTER_ID));
+      assertTrue(testConsumer.payload.contains(CHANNEL_ID));
+      assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
+      assertTrue(testConsumer.payload.contains(WORKFLOW_ID2));
+    } finally {
+      wrapper.destroy();
+    }
   }
-  
-  
+
+  @Test
+  public void testLiveness() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check/alive");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+      assertFalse(testConsumer.isError);
+      assertEquals("", testConsumer.payload);
+    } finally {
+      wrapper.destroy();
+    }
+  }
+
+  @Test
+  public void testReadiness_NotReady() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+      assertTrue(testConsumer.isError);
+      assertTrue(testConsumer.storedException.getMessage().contains("is not started"));
+      assertEquals(HttpURLConnection.HTTP_UNAVAILABLE, testConsumer.httpStatus);
+    } finally {
+      wrapper.destroy();
+    }
+  }
+
+  @Test
+  public void testReadiness_Ready() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+    try {
+      wrapper.start();
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(testConsumer::complete);
+      assertFalse(testConsumer.isError);
+      assertEquals("", testConsumer.payload);
+    } finally {
+      wrapper.destroy();
+    }
+  }
+
+  // Can't do this in @Before / @After since I want to control the mocking behaviour.
+  private class MockedHealthCheckWrapper {
+
+    private WorkflowHealthCheckComponent healthCheck;
+    private TestConsumer testConsumer;
+
+    @Mock
+    private JmxMBeanHelper mockJmxHelper;
+
+    public MockedHealthCheckWrapper() throws Exception {
+      MockitoAnnotations.initMocks(this);
+    }
+
+    public MockedHealthCheckWrapper build(boolean workflowsAreStarted) throws Exception {
+      ObjectName adapterObjectName = new ObjectName("com.adaptris:type=Adapter,id=" + ADAPTER_ID);
+      ObjectInstance adapter =
+          new ObjectInstance(adapterObjectName, AdapterManager.class.getName());
+      Set<ObjectInstance> adapterInstances = new HashSet<>();
+      adapterInstances.add(adapter);
+
+      Set<ObjectName> channelObjectNames = new HashSet<>();
+      ObjectName channelObjectName = new ObjectName(CHANNEL_OBJECT_NAME);
+      channelObjectNames.add(channelObjectName);
+
+      Set<ObjectName> workflowObjectNames = new HashSet<>();
+      ObjectName workflowObjectName1 = new ObjectName(WORKFLOW_OBJECT_NAME_1);
+      ObjectName workflowObjectName2 = new ObjectName(WORKFLOW_OBJECT_NAME_2);
+      workflowObjectNames.add(workflowObjectName1);
+      workflowObjectNames.add(workflowObjectName2);
+
+
+      when(mockJmxHelper.getMBeans(anyString())).thenReturn(adapterInstances);
+      when(mockJmxHelper.getStringAttribute(adapterObjectName.toString(), UNIQUE_ID))
+          .thenReturn(ADAPTER_ID);
+      when(mockJmxHelper.getStringAttributeClassName(adapterObjectName.toString(), COMPONENT_STATE))
+          .thenReturn(StartedState.class.getSimpleName());
+
+      when(mockJmxHelper.getObjectSetAttribute(adapterObjectName.toString(), CHILDREN_ATTRIBUTE))
+          .thenReturn(channelObjectNames);
+      when(mockJmxHelper.getStringAttribute(channelObjectName.toString(), UNIQUE_ID))
+          .thenReturn(CHANNEL_ID);
+      when(mockJmxHelper.getStringAttributeClassName(channelObjectName.toString(), COMPONENT_STATE))
+          .thenReturn(StartedState.class.getSimpleName());
+
+      when(mockJmxHelper.getObjectSetAttribute(channelObjectName.toString(), CHILDREN_ATTRIBUTE))
+          .thenReturn(workflowObjectNames);
+
+      String workflowState = StartedState.class.getSimpleName();
+      if (!workflowsAreStarted) {
+        workflowState = StoppedState.class.getSimpleName();
+      }
+
+      when(mockJmxHelper.getStringAttribute(workflowObjectName1.toString(), UNIQUE_ID))
+          .thenReturn(WORKFLOW_ID1);
+      when(mockJmxHelper.getStringAttributeClassName(workflowObjectName1.toString(),
+          COMPONENT_STATE)).thenReturn(workflowState);
+
+      when(mockJmxHelper.getStringAttribute(workflowObjectName2.toString(), UNIQUE_ID))
+          .thenReturn(WORKFLOW_ID2);
+      when(mockJmxHelper.getStringAttributeClassName(workflowObjectName2.toString(),
+            COMPONENT_STATE)).thenReturn(workflowState);
+
+      healthCheck = new WorkflowHealthCheckComponent();
+      testConsumer = new TestConsumer();
+      healthCheck.setConsumer(testConsumer);
+      healthCheck.setJmxMBeanHelper(mockJmxHelper);
+      return this;
+    }
+
+
+    public void start() throws Exception {
+      healthCheck.init(new Properties());
+      healthCheck.start();
+
+    }
+
+    public void destroy() throws Exception {
+      healthCheck.stop();
+      healthCheck.destroy();
+    }
+
+    public WorkflowHealthCheckComponent healthCheck() {
+      return healthCheck;
+    }
+
+    public TestConsumer testConsumer() {
+      return testConsumer;
+    }
+
+    public JmxMBeanHelper jmxHelper() {
+      return mockJmxHelper;
+    }
+
+  }
+
   class TestConsumer extends WorkflowServicesConsumer {
-    
+
     String payload;
     boolean isError;
+    Exception storedException;
+    int httpStatus = -1;
 
     @Override
     protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
@@ -271,17 +358,20 @@ public class WorkflowHealthCheckComponentTest {
 
 
     @Override
-    public void doErrorResponse(AdaptrisMessage message, Exception e, String contentType) throws ServiceException {
+    public void doErrorResponse(AdaptrisMessage message, Exception e, int status)
+        throws ServiceException {
       isError = true;
+      storedException = e;
+      httpStatus = status;
     }
-    
+
     public boolean complete() {
       return isError == true || payload != null;
     }
-    
+
     @Override
     public void prepare() {
-      
+
     }
   }
 }

--- a/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
@@ -1,7 +1,8 @@
 package com.adaptris.rest;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -139,12 +140,12 @@ public class WorkflowServicesComponentTest {
   @Test
   public void testErrorResponse() throws Exception {
     startComponent();
-    
+
     message.addMessageHeader(PATH_KEY, "/workflow-services/1/2/3/4/5/6/7/8/9");
     workflowServicesComponent.onAdaptrisMessage(message);
-    
+
     verify(mockJmxClient, times(0)).process(any(), any());
-    verify(mockConsumer).doErrorResponse(any(), any(), any());
+    verify(mockConsumer).doErrorResponse(any(), any(), anyInt());
   }
   
   private void startComponent() throws Exception {

--- a/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
+++ b/src/test/java/com/adaptris/rest/WorkflowServicesConsumerTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
-import java.util.EnumSet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.Before;
@@ -13,29 +12,23 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.MDC;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.http.jetty.JettyMessageConsumer;
-import com.adaptris.core.http.jetty.JettyResponseService;
-import com.adaptris.core.http.jetty.NoOpResponseHeaderProvider;
-import com.adaptris.core.stubs.DefectiveMessageFactory;
-import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
 import com.adaptris.core.stubs.MockMessageListener;
 
 public class WorkflowServicesConsumerTest {
-  
+
   private WorkflowServicesConsumer servicesConsumer;
-  
+
   @Mock private StandaloneConsumer mockStandaloneConsumer;
-  
+
   @Mock private AdaptrisMessageListener mockMessageListener;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    
+
     servicesConsumer = new HttpRestWorkflowServicesConsumer("WorkflowServicesConsumerTest");
     servicesConsumer.setMessageListener(mockMessageListener);
     servicesConsumer.setAcceptedHttpMethods("POST,GET");
@@ -45,13 +38,13 @@ public class WorkflowServicesConsumerTest {
   @Test
   public void testLifecycle() throws Exception {
     servicesConsumer.prepare();
-    
+
     servicesConsumer.setStandaloneConsumer(mockStandaloneConsumer);
     servicesConsumer.init();
     servicesConsumer.start();
     servicesConsumer.stop();
     servicesConsumer.close();
-    
+
     verify(mockStandaloneConsumer).requestInit();
     verify(mockStandaloneConsumer).requestStart();
     verify(mockStandaloneConsumer).requestStop();
@@ -69,18 +62,8 @@ public class WorkflowServicesConsumerTest {
           Mockito.mock(HttpServletResponse.class));
       fail();
     } catch (Exception expected) {
-      
+
     }
     assertEquals("WorkflowServicesConsumerTest", MDC.get(AbstractRestfulEndpoint.MDC_KEY));
-  }
-
-  @Test
-  public void testSendErrorQuietly() throws Exception {
-    HttpRestWorkflowServicesConsumer consumer = new HttpRestWorkflowServicesConsumer("WorkflowServicesConsumerTest");
-    consumer.setResponseService(new JettyResponseService().withResponseHeaderProvider(new NoOpResponseHeaderProvider()));
-    AdaptrisMessage m1 = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    WorkflowServicesConsumer.sendErrorResponseQuietly(consumer, m1, new Exception());
-    AdaptrisMessage m2 = new DefectiveMessageFactory(EnumSet.allOf(WhenToBreak.class)).newMessage();
-    WorkflowServicesConsumer.sendErrorResponseQuietly(consumer, m2, new Exception());
   }
 }

--- a/src/test/java/com/adaptris/rest/util/Dummy.java
+++ b/src/test/java/com/adaptris/rest/util/Dummy.java
@@ -1,0 +1,28 @@
+package com.adaptris.rest.util;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import javax.management.ObjectName;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class Dummy implements DummyMBean {
+
+  @Getter
+  private final String uniqueId = UUID.randomUUID().toString();
+
+  @Getter
+  @Setter(AccessLevel.PRIVATE)
+  private Set<ObjectName> children;
+
+  public Dummy(int count) throws Exception {
+    Set<ObjectName> offspring = new HashSet<>();
+    for (int i = 0; i < count; i++) {
+      String childRef = String.format(DUMMY_MBEAN_CHILD_BASE, getUniqueId(), UUID.randomUUID().toString());
+      offspring.add(ObjectName.getInstance(childRef));
+    }
+    setChildren(offspring);
+  }
+}

--- a/src/test/java/com/adaptris/rest/util/DummyMBean.java
+++ b/src/test/java/com/adaptris/rest/util/DummyMBean.java
@@ -1,0 +1,14 @@
+package com.adaptris.rest.util;
+
+import java.util.Set;
+import javax.management.ObjectName;
+
+public interface DummyMBean {
+
+  String DUMMY_MBEAN_BASE = "com.adaptris:type=Dummy,name=%s";
+  String DUMMY_MBEAN_CHILD_BASE = "com.adaptris:type=Dummy,name=%s,child=%s";
+
+  String getUniqueId();
+
+  Set<ObjectName> getChildren();
+}

--- a/src/test/java/com/adaptris/rest/util/JmxHelperTest.java
+++ b/src/test/java/com/adaptris/rest/util/JmxHelperTest.java
@@ -1,0 +1,92 @@
+package com.adaptris.rest.util;
+
+import static com.adaptris.rest.util.DummyMBean.DUMMY_MBEAN_BASE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.util.Set;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import org.junit.Test;
+
+public class JmxHelperTest {
+
+  private static final String MY_SEARCH_CRITERIA = "com.adaptris:type=Dummy,*";
+  private static final String UID_ATTR = "UniqueId";
+  private static final String CHILDREN_ATTR = "Children";
+
+  @Test
+  public void testGetStringAttribute() throws Exception {
+    JmxMBeanHelper helper = new JmxMBeanHelper();
+    MBeanServer server = helper.mBeanServer();
+    Dummy dummy = new Dummy(0);
+    String objectRef = String.format(DUMMY_MBEAN_BASE, dummy.getUniqueId());
+    try {
+      server.registerMBean(dummy, ObjectName.getInstance(objectRef));
+      assertEquals(dummy.getUniqueId(), helper.getStringAttribute(objectRef, UID_ATTR));
+    } finally {
+      server.unregisterMBean(ObjectName.getInstance(objectRef));
+    }
+  }
+
+  @Test
+  public void testGetStringAttributeClassName() throws Exception {
+    JmxMBeanHelper helper = new JmxMBeanHelper();
+    MBeanServer server = helper.mBeanServer();
+    Dummy dummy = new Dummy(0);
+    String objectRef = String.format(DUMMY_MBEAN_BASE, dummy.getUniqueId());
+    try {
+      server.registerMBean(dummy, ObjectName.getInstance(objectRef));
+      assertEquals("String", helper.getStringAttributeClassName(objectRef, UID_ATTR));
+    } finally {
+      server.unregisterMBean(ObjectName.getInstance(objectRef));
+    }
+  }
+
+  @Test
+  public void testProxyMBean() throws Exception {
+    JmxMBeanHelper helper = new JmxMBeanHelper();
+    MBeanServer server = helper.mBeanServer();
+    Dummy dummy = new Dummy(0);
+    String objectRef = String.format(DUMMY_MBEAN_BASE, dummy.getUniqueId());
+    try {
+      server.registerMBean(dummy, ObjectName.getInstance(objectRef));
+      DummyMBean mbean = helper.proxyMBean(objectRef, DummyMBean.class);
+      assertNotNull(mbean);
+      assertEquals(dummy.getUniqueId(), mbean.getUniqueId());
+    } finally {
+      server.unregisterMBean(ObjectName.getInstance(objectRef));
+    }
+  }
+
+  @Test
+  public void testGetObjectSetAttribute() throws Exception {
+    JmxMBeanHelper helper = new JmxMBeanHelper();
+    MBeanServer server = helper.mBeanServer();
+    Dummy dummy = new Dummy(10);
+    String objectRef = String.format(DUMMY_MBEAN_BASE, dummy.getUniqueId());
+    try {
+      server.registerMBean(dummy, ObjectName.getInstance(objectRef));
+      Set<ObjectName> set = helper.getObjectSetAttribute(objectRef, CHILDREN_ATTR);
+      assertEquals(10, set.size());
+    } finally {
+      server.unregisterMBean(ObjectName.getInstance(objectRef));
+    }
+  }
+
+  @Test
+  public void testGetMBeans() throws Exception {
+    JmxMBeanHelper helper = new JmxMBeanHelper();
+    MBeanServer server = helper.mBeanServer();
+    Dummy dummy = new Dummy(0);
+    String objectRef = String.format(DUMMY_MBEAN_BASE, dummy.getUniqueId());
+    try {
+      server.registerMBean(dummy, ObjectName.getInstance(objectRef));
+      Set<ObjectInstance> set = helper.getMBeans(MY_SEARCH_CRITERIA);
+      assertEquals(1, set.size());
+    } finally {
+      server.unregisterMBean(ObjectName.getInstance(objectRef));
+    }
+  }
+
+}


### PR DESCRIPTION
## Motivation

In the context of deploying interlok into kubernetes we often have the situation where we are asked to provide an endpoint that supplies "readiness" and "liveness" information.
The existing health-check management component was born as a result of that; however, the controllers that want to use the probes don't care about the data (i.e. they don't want to parse the JSON array), they just want to use status codes.

- /{base}/alive should return 200 OK (in most cases)
- /{base}/ready should return 200 OK if we're ready to start processing messages.
- /{base}/ready should return 503 Unavailable if we're not ready to start processing messages.

## Modification

- Remove /{base}/{adapter-id}/{channel-id}/{workflow-id} pathing since there isn't a good use case here that can't be achieved by mangling the /{base}/ JSON array output.
- Move configuredUrlPath to abstract-rest-endpoint delegating the default down to concrete implementations
- Added /{base}/alive to report _liveness_
- Added /{base}/ready to report _readiness_
- Tighten up Getter/Setter use so they aren't public. Package or protected for mocking

(probably want to squash and merge)...

## Result

- /health-check/{adapter-id}/{channel-id}/{workflow-id}  no longer works.
- /health-check/ -> provides the JSON array as always
-/health-check/alive -> returns 200 OK if jetty was started and triggered us
- /health-check/ready -> returns 200 OK if all the adapters/channels/workflows were started, 503 otherwise with the first "not-started" component being returned.

## Testing

Create your adapter as normal, and enable the health-check component.
You can check the expected behaviours in README.md
