### PR TITLE
Interlok 3407 prometheus scrape

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,8 @@ dependencies {
   compile ("com.adaptris:interlok-client:$interlokCoreVersion")
 
   compile "com.adaptris:interlok-cluster-manager:$interlokCoreVersion", optional
+  
+  compile "com.adaptris:interlok-monitor-agent:$interlokCoreVersion", optional
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion")
   umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")

--- a/src/main/java/com/adaptris/rest/PrometheusMetricsComponent.java
+++ b/src/main/java/com/adaptris/rest/PrometheusMetricsComponent.java
@@ -1,0 +1,295 @@
+package com.adaptris.rest;
+
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import javax.management.ObjectName;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.monitor.agent.activity.ActivityMap;
+import com.adaptris.monitor.agent.activity.AdapterActivity;
+import com.adaptris.monitor.agent.activity.BaseActivity;
+import com.adaptris.monitor.agent.activity.ChannelActivity;
+import com.adaptris.monitor.agent.activity.ProducerActivity;
+import com.adaptris.monitor.agent.activity.ServiceActivity;
+import com.adaptris.monitor.agent.activity.WorkflowActivity;
+import com.adaptris.monitor.agent.jmx.ProfilerEventClientMBean;
+import com.adaptris.rest.util.JmxMBeanHelper;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class PrometheusMetricsComponent extends AbstractRestfulEndpoint {
+  
+  private static final String ACCEPTED_FILTER = "GET";
+
+  private static final String DEFAULT_PATH = "/prometheus/metrics/*";
+
+  private static final String PROFILER_OBJECT_NAME = "com.adaptris:type=Profiler";
+    
+  private enum Metrics {
+    WORKFLOW_MESSAGE_COUNT_METRIC ("workflowMessageCount") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);
+        this.calculateAndAddTotalValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The number of messages processed by this workflow since the last time we checked."; }
+    },
+    
+    WORKFLOW_MESSAGE_FAIL_COUNT_METRIC ("workflowMessageFailCount") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);        
+        this.calculateAndAddTotalValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The number of messages processed by this workflow that have failed since the last time we checked."; }
+    },
+    
+    WORKFLOW_AVG_TIME_NANOS_METRIC ("workflowAvgNanos") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);
+        this.calculateAndAddAvgValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The average amount of time in nanoseconds this workflow takes to process a single message."; }
+    },
+    
+    WORKFLOW_AVG_TIME_MILLIS_METRIC ("workflowAvgMillis") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);
+        this.calculateAndAddAvgValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The average amount of time in millisecods this workflow takes to process a single message."; }
+    },
+    
+    SERVICE_AVG_TIME_NANOS_METRIC ("serviceAvgNanos") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);
+        this.calculateAndAddAvgValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The average amount of time in nanoseconds this service takes to process a single message."; }
+    },
+    
+    SERVICE_AVG_TIME_MILLIS_METRIC ("serviceAvgMillis") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);
+        this.calculateAndAddAvgValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The average amount of time in millisecods this service takes to process a single message."; }
+    },
+    
+    PRODUCER_AVG_TIME_NANOS_METRIC ("producerAvgNanos") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);
+        this.calculateAndAddAvgValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The average amount of time in nanoseconds this producer takes to process a single message."; }
+    },
+  
+    PRODUCER_AVG_TIME_MILLIS_METRIC ("producerAvgMillis") {
+      @Override
+      public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
+        String metricName = this.createMetricName(workflowId, activityId);
+        this.calculateAndAddAvgValue(metricName, metricMap, value);
+      }
+
+      @Override
+      public String getHelp() { return "The average amount of time in milliseconds this producer takes to process a single message."; }
+    };
+    
+    private String metricName;
+    
+    private Metrics(String name) {
+      setMetricName(name);
+    }
+
+    public String getMetricName() {
+      return metricName;
+    }
+
+    public void setMetricName(String metricName) {
+      this.metricName = metricName;
+    }
+    
+    public abstract void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap);
+    
+    public abstract String getHelp();
+    
+    public String createMetricName(String workflowId, String activityId) {
+      StringBuffer returnValue = new StringBuffer();
+      returnValue.append(getMetricName());
+      returnValue.append("_");
+      returnValue.append(workflowId.replace(".", "").replace("-", "").replace("_", ""));
+      if(activityId != null) {
+        returnValue.append("_");
+        returnValue.append(activityId.replace(".", "").replace("-", "").replace("_", ""));  
+      }
+      
+      return returnValue.toString();
+    }
+    
+    public void calculateAndAddAvgValue(String metricName, Map<String, MetricHelpTypeAndValue> metricMap, Double newValue) {
+      Optional<MetricHelpTypeAndValue> metricHelpTypeValue = Optional.ofNullable(metricMap.get(metricName));
+      metricHelpTypeValue.ifPresent( oldMetricHelpTypeValue -> {
+        oldMetricHelpTypeValue.setValue((newValue + oldMetricHelpTypeValue.getValue()) / 2);
+      });        
+      metricMap.put(metricName, metricHelpTypeValue.isPresent() ? metricHelpTypeValue.get() : metricHelpTypeValue.orElseGet(() -> new MetricHelpTypeAndValue(getHelp(), newValue)));
+    }
+    
+    public void calculateAndAddTotalValue(String metricName, Map<String, MetricHelpTypeAndValue> metricMap, Double newValue) {
+      Optional<MetricHelpTypeAndValue> metricHelpTypeValue = Optional.ofNullable(metricMap.get(metricName));
+      metricHelpTypeValue.ifPresent( oldMetricHelpTypeValue -> {
+        oldMetricHelpTypeValue.setValue(newValue + oldMetricHelpTypeValue.getValue());
+      });        
+      metricMap.put(metricName, metricHelpTypeValue.isPresent() ? metricHelpTypeValue.get() : metricHelpTypeValue.orElseGet(() -> new MetricHelpTypeAndValue(getHelp(), newValue)));
+    }
+  }
+  
+  @Getter(AccessLevel.PROTECTED)
+  private transient final String defaultUrlPath = DEFAULT_PATH;
+
+  @Getter(AccessLevel.PROTECTED)
+  private transient final String acceptedFilter = ACCEPTED_FILTER;
+  
+  @Getter(AccessLevel.PACKAGE)
+  @Setter(AccessLevel.PACKAGE)
+  private transient JmxMBeanHelper jmxMBeanHelper;
+  
+  @Getter
+  @Setter
+  private ProfilerEventClientMBean profilerEventClient;
+
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage message, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    try {
+      this.loadProfilerEventClient();
+      
+      if(this.getProfilerEventClient() == null) {
+        log.warn("No profiling events found.  Continuing...");
+        message.setContent("", message.getContentEncoding());
+        getConsumer().doResponse(message, message, HttpRestWorkflowServicesConsumer.CONTENT_TYPE_DEFAULT);
+        success.accept(message);
+        return;
+      }
+        
+      Map<String, MetricHelpTypeAndValue> profilingEvents = new HashMap<>();
+      ActivityMap eventActivityMap = this.getProfilerEventClient().getEventActivityMap();
+      while(eventActivityMap != null) {
+        eventActivityMap.getAdapters().forEach( (adapterId, adapterActivity) -> {
+          ((AdapterActivity) adapterActivity).getChannels().forEach( (channelId, channelActivity) -> {
+            ((ChannelActivity) channelActivity).getWorkflows().forEach( ( workflowId, workflowActivity) -> {
+              addMetrics(null, workflowActivity, profilingEvents);
+            });
+          });
+        });
+        
+        eventActivityMap = this.getProfilerEventClient().getEventActivityMap();
+      }
+      
+      message.setContent(this.stringifyMap(profilingEvents), message.getContentEncoding());
+      
+      getConsumer().doResponse(message, message);
+      success.accept(message);
+      
+    } catch (Exception ex) {
+      getConsumer().doErrorResponse(message, ex, ERROR_DEFAULT);
+      failure.accept(message);
+    }
+  }
+  
+  private String stringifyMap(Map<String, MetricHelpTypeAndValue> profilingEvents) {
+    StringBuffer buffer = new StringBuffer();
+    
+    profilingEvents.forEach( (metricName, metric) -> {
+      buffer.append("# HELP ");
+      buffer.append(metric.getHelp());
+      buffer.append("\n");
+      buffer.append(metricName);
+      buffer.append(" ");
+      buffer.append(metric.getValue());
+      buffer.append("\n");
+    });
+    
+    return buffer.toString();
+  }
+
+  private void addMetrics(WorkflowActivity workflowActivity, BaseActivity activity, Map<String, MetricHelpTypeAndValue> profilingEvents) {
+    if(activity instanceof WorkflowActivity) {
+      WorkflowActivity wActivity = (WorkflowActivity) activity;
+      this.addMetrics(wActivity, wActivity.getProducerActivity(), profilingEvents);
+      wActivity.getServices().forEach( ( serviceId, serviceActivity) -> {
+        this.addMetrics(wActivity, serviceActivity, profilingEvents);
+      });
+      
+      Metrics.WORKFLOW_MESSAGE_COUNT_METRIC.addMetric(wActivity.getUniqueId(), null, (double) wActivity.getMessageCount(), profilingEvents);
+      Metrics.WORKFLOW_MESSAGE_FAIL_COUNT_METRIC.addMetric(wActivity.getUniqueId(), null, (double) wActivity.getFailedCount(), profilingEvents);
+      Metrics.WORKFLOW_AVG_TIME_NANOS_METRIC.addMetric(wActivity.getUniqueId(), null, (double) wActivity.getAvgNsTaken(), profilingEvents);
+      Metrics.WORKFLOW_AVG_TIME_MILLIS_METRIC.addMetric(wActivity.getUniqueId(), null, (double) wActivity.getAvgMsTaken(), profilingEvents);
+      
+    } else if (activity instanceof ProducerActivity) {
+      ProducerActivity pActivity = (ProducerActivity) activity;
+      
+      Metrics.PRODUCER_AVG_TIME_NANOS_METRIC.addMetric(workflowActivity.getUniqueId(), pActivity.getUniqueId(), (double) pActivity.getAvgNsTaken(), profilingEvents);
+      Metrics.PRODUCER_AVG_TIME_MILLIS_METRIC.addMetric(workflowActivity.getUniqueId(), pActivity.getUniqueId(), (double) pActivity.getAvgMsTaken(), profilingEvents);
+      
+    } else if (activity instanceof ServiceActivity) {
+      ServiceActivity sActivity = (ServiceActivity) activity;
+      
+      Metrics.SERVICE_AVG_TIME_NANOS_METRIC.addMetric(workflowActivity.getUniqueId(), sActivity.getUniqueId(), (double) sActivity.getAvgNsTaken(), profilingEvents);
+      Metrics.SERVICE_AVG_TIME_MILLIS_METRIC.addMetric(workflowActivity.getUniqueId(), sActivity.getUniqueId(), (double) sActivity.getAvgMsTaken(), profilingEvents);
+      
+      sActivity.getServices().forEach( (serviceId, serviceActivity) -> {
+        this.addMetrics(workflowActivity, serviceActivity, profilingEvents);
+      });
+    }
+    
+  }
+
+  private void loadProfilerEventClient() throws Exception {    
+    if(this.getProfilerEventClient() == null) {
+      ProfilerEventClientMBean profilerEventClientMBean = getJmxMBeanHelper().proxyMBean(new ObjectName(PROFILER_OBJECT_NAME).toString(), ProfilerEventClientMBean.class);
+      if(profilerEventClientMBean != null)
+        this.setProfilerEventClient(profilerEventClientMBean);
+    }
+  }
+  
+  static class MetricHelpTypeAndValue {
+    @Getter
+    @Setter
+    private String help;
+    
+    @Getter
+    @Setter
+    private Double value;
+    
+    public MetricHelpTypeAndValue(String help, Double value) {
+      this.setHelp(help);
+      this.setValue(value);
+    }
+  }
+
+}

--- a/src/main/java/com/adaptris/rest/PrometheusMetricsComponent.java
+++ b/src/main/java/com/adaptris/rest/PrometheusMetricsComponent.java
@@ -183,6 +183,10 @@ public class PrometheusMetricsComponent extends AbstractRestfulEndpoint {
   @Setter
   private ProfilerEventClientMBean profilerEventClient;
 
+  public PrometheusMetricsComponent() {
+    this.setJmxMBeanHelper(new JmxMBeanHelper());
+  }
+  
   @Override
   public void onAdaptrisMessage(AdaptrisMessage message, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
     try {

--- a/src/main/resources/META-INF/com/adaptris/core/management/components/prometheus-rest
+++ b/src/main/resources/META-INF/com/adaptris/core/management/components/prometheus-rest
@@ -1,0 +1,1 @@
+class=com.adaptris.rest.PrometheusMetricsComponent

--- a/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
+++ b/src/test/java/com/adaptris/rest/ClusterManagerComponentTest.java
@@ -5,20 +5,22 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+
 import javax.management.MalformedObjectNameException;
+
 import org.awaitility.Durations;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.cache.ExpiringMapCache;
 import com.adaptris.mgmt.cluster.ClusterInstance;
@@ -31,7 +33,7 @@ public class ClusterManagerComponentTest {
 
   private ClusterManagerComponent clusterManagerComponent;
 
-  private TestConsumer testConsumer = new TestConsumer();
+  private MockWorkflowConsumer testConsumer = new MockWorkflowConsumer();
 
   private ExpiringMapCache expiringMapCache;
 
@@ -47,7 +49,7 @@ public class ClusterManagerComponentTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
 
@@ -151,40 +153,5 @@ public class ClusterManagerComponentTest {
       .until(testConsumer::complete);
 
     assertTrue(testConsumer.isError);
-  }
-
-  class TestConsumer extends WorkflowServicesConsumer {
-
-    String payload;
-    boolean isError;
-    int httpStatus = -1;
-
-    @Override
-    protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
-      return null;
-    }
-
-    @Override
-    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
-        String contentType, int status) {
-      payload = processedMessage.getContent();
-      httpStatus = status;
-    }
-
-
-    @Override
-    public void doErrorResponse(AdaptrisMessage message, Exception e, int status) {
-      isError = true;
-      httpStatus = status;
-    }
-
-    public boolean complete() {
-      return isError == true || payload != null;
-    }
-
-    @Override
-    public void prepare() {
-
-    }
   }
 }

--- a/src/test/java/com/adaptris/rest/MockWorkflowConsumer.java
+++ b/src/test/java/com/adaptris/rest/MockWorkflowConsumer.java
@@ -1,0 +1,40 @@
+package com.adaptris.rest;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageListener;
+import com.adaptris.core.StandaloneConsumer;
+
+public class MockWorkflowConsumer extends WorkflowServicesConsumer {
+
+  String payload;
+  boolean isError;
+  int httpStatus = -1;
+
+  @Override
+  protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
+    return null;
+  }
+
+  @Override
+  protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
+      String contentType, int status) {
+    payload = processedMessage.getContent();
+    httpStatus = status;
+  }
+
+
+  @Override
+  public void doErrorResponse(AdaptrisMessage message, Exception e, int status) {
+    isError = true;
+    httpStatus = status;
+  }
+
+  public boolean complete() {
+    return isError == true || payload != null;
+  }
+
+  @Override
+  public void prepare() {
+
+  }
+}

--- a/src/test/java/com/adaptris/rest/PrometheusMetricsComponentTest.java
+++ b/src/test/java/com/adaptris/rest/PrometheusMetricsComponentTest.java
@@ -1,0 +1,173 @@
+package com.adaptris.rest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.monitor.agent.activity.ActivityMap;
+import com.adaptris.monitor.agent.activity.AdapterActivity;
+import com.adaptris.monitor.agent.activity.ChannelActivity;
+import com.adaptris.monitor.agent.activity.ConsumerActivity;
+import com.adaptris.monitor.agent.activity.ProducerActivity;
+import com.adaptris.monitor.agent.activity.ServiceActivity;
+import com.adaptris.monitor.agent.activity.WorkflowActivity;
+import com.adaptris.monitor.agent.jmx.ProfilerEventClientMBean;
+import com.adaptris.rest.util.JmxMBeanHelper;
+
+public class PrometheusMetricsComponentTest {
+  
+  private PrometheusMetricsComponent component;
+  
+  private AdaptrisMessage message;
+  
+  @Mock private ProfilerEventClientMBean mockMBean;
+  
+  @Mock private JmxMBeanHelper mockJmxHelper;
+
+  private ActivityMap activityMap;
+  
+  private MockWorkflowConsumer mockConsumer;
+  
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    
+    mockConsumer = new MockWorkflowConsumer();
+    
+    component = new PrometheusMetricsComponent();
+    component.setConsumer(mockConsumer);
+    component.setProfilerEventClient(mockMBean);
+    component.setJmxMBeanHelper(mockJmxHelper);
+    
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    
+    activityMap = buildActivityMap();
+    
+    when(mockMBean.getEventActivityMap())
+        .thenReturn(activityMap)
+        .thenReturn(null);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+
+  @Test
+  public void testNoMetrics() throws Exception {
+    when(mockMBean.getEventActivityMap())
+        .thenReturn(null);
+    
+    component.onAdaptrisMessage(message);
+    
+    assertFalse(mockConsumer.isError);
+    assertTrue(mockConsumer.payload.equals(""));
+  }
+  
+  @Test
+  public void testNoProfilingMBeanNoMetrics() throws Exception {
+    component.setProfilerEventClient(null);
+    
+    when(mockJmxHelper.proxyMBean(anyString(), any()))
+        .thenReturn(null);
+    
+    component.onAdaptrisMessage(message);
+    
+    assertFalse(mockConsumer.isError);
+    assertTrue(mockConsumer.payload.equals(""));
+  }
+  
+  @Test
+  public void testNoProfilingMBeanIsCreated() throws Exception {
+    component.setProfilerEventClient(null);
+    
+    when(mockJmxHelper.proxyMBean(anyString(), any()))
+        .thenReturn(mockMBean);
+    
+    component.onAdaptrisMessage(message);
+    
+    assertFalse(mockConsumer.isError);
+    assertTrue(mockConsumer.payload.contains("workflowMessageCount_workflow"));
+    assertTrue(mockConsumer.payload.contains("workflowAvgNanos_workflow"));
+    assertTrue(mockConsumer.payload.contains("serviceAvgNanos_workflow_service"));
+    assertTrue(mockConsumer.payload.contains("producerAvgNanos_workflow_producer"));
+  }
+  
+  @Test
+  public void testErrorResponseOnException() throws Exception {
+    activityMap.setAdapters(null);
+    
+    component.onAdaptrisMessage(message);
+    
+    assertTrue(mockConsumer.isError);
+    assertTrue(mockConsumer.httpStatus == 500);
+  }
+  
+  @Test
+  public void testMetricsReturns() throws Exception {
+    component.onAdaptrisMessage(message);
+    
+    assertTrue(mockConsumer.payload.contains("workflowMessageCount_workflow"));
+    assertTrue(mockConsumer.payload.contains("workflowAvgNanos_workflow"));
+    assertTrue(mockConsumer.payload.contains("serviceAvgNanos_workflow_service"));
+    assertTrue(mockConsumer.payload.contains("producerAvgNanos_workflow_producer"));
+  }
+  
+  @Test
+  public void testMultipleMetricsReturns() throws Exception {
+    when(mockMBean.getEventActivityMap())
+        .thenReturn(activityMap)
+        .thenReturn(activityMap)
+        .thenReturn(activityMap)
+        .thenReturn(null);
+    
+    component.onAdaptrisMessage(message);
+    
+    assertTrue(mockConsumer.payload.contains("workflowMessageCount_workflow"));
+    assertTrue(mockConsumer.payload.contains("workflowAvgNanos_workflow"));
+    assertTrue(mockConsumer.payload.contains("serviceAvgNanos_workflow_service"));
+    assertTrue(mockConsumer.payload.contains("producerAvgNanos_workflow_producer"));
+  }
+  
+  private ActivityMap buildActivityMap() {
+    ActivityMap map = new ActivityMap();
+    
+    AdapterActivity adapter = new AdapterActivity();
+    adapter.setUniqueId("adapter");
+    ChannelActivity channel = new ChannelActivity();
+    channel.setUniqueId("channel");
+    WorkflowActivity workflow = new WorkflowActivity();
+    workflow.setUniqueId("workflow");
+    ProducerActivity producer = new ProducerActivity();
+    producer.setUniqueId("producer");
+    ConsumerActivity consumer = new ConsumerActivity();
+    consumer.setUniqueId("consumer");
+    ServiceActivity service = new ServiceActivity();
+    service.setUniqueId("service");
+    ServiceActivity innerService = new ServiceActivity();
+    innerService.setUniqueId("innerService");
+    
+    service.getServices().put(innerService.getUniqueId(), innerService);
+    
+    workflow.setConsumerActivity(consumer);
+    workflow.setProducerActivity(producer);
+    workflow.getServices().put(service.getUniqueId(), service);
+    
+    channel.getWorkflows().put(workflow.getUniqueId(), workflow);
+    adapter.getChannels().put(channel.getUniqueId(), channel);
+    
+    map.getAdapters().put(adapter.getUniqueId(), adapter);
+    
+    return map;
+  }
+}


### PR DESCRIPTION
## Motivation

We can currently push metrics into Prometheus via the Pushgateway, however it's not the most common of techniques to use and may not be supported in some environments.
Therefore we need to serve up a HTTP endpoint that Prometheus can scrape for metrics.

## Modification

Simply added a new RESTful service in the interlok-workflow-rest-services project.
As the others in that project this is a new management component named "prometheus-rest".
I've also extracted out a mock test class from one of the other unit tests so it can be reused for this new components tests.

## Result

Firing a GET request at *http://host:port/prometheus/metrics* will now return a text based report on the metrics built up from JMX since the last time they were requested.  The format is human readable of course, but probably useless to anything except Prometheus.

## Testing

As long as you have the profiler running, active messages flowing through your adapter and you add "prometheus-rest" to your management components then you can simply GET *http://host:port/prometheus/metrics* in your browser to see the full list of available metrics.
