### PR TITLE
INTERLOK-3587

### DIFF
--- a/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGenerator.java
+++ b/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGenerator.java
@@ -1,6 +1,7 @@
 package com.adaptris.rest.metrics.interlok;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -86,8 +87,8 @@ public class InterlokProfilerMetricsGenerator extends MgmtComponentImpl implemen
     }
     
     Map<String, MetricHelpTypeAndValue> profilingEvents = new HashMap<>();
-    ActivityMap eventActivityMap = this.getProfilerEventClient().getEventActivityMap();
-    while(eventActivityMap != null) {
+    List<ActivityMap> eventActivityMaps = this.getProfilerEventClient().getEventActivityMaps();
+    for(ActivityMap eventActivityMap : eventActivityMaps) {
       eventActivityMap.getAdapters().forEach( (adapterId, adapterActivity) -> {
         ((AdapterActivity) adapterActivity).getChannels().forEach( (channelId, channelActivity) -> {
           ((ChannelActivity) channelActivity).getWorkflows().forEach( ( workflowId, workflowActivity) -> {
@@ -95,8 +96,6 @@ public class InterlokProfilerMetricsGenerator extends MgmtComponentImpl implemen
           });
         });
       });
-      
-      eventActivityMap = this.getProfilerEventClient().getEventActivityMap();
     }
     
     profilingEvents.forEach( (metricName, helpValueTags) -> {

--- a/interlok-rest-metrics-profiler/src/test/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGeneratorTest.java
+++ b/interlok-rest-metrics-profiler/src/test/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGeneratorTest.java
@@ -6,6 +6,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,10 +51,11 @@ public class InterlokProfilerMetricsGeneratorTest {
     component.setJmxMBeanHelper(mockJmxHelper);
     
     activityMap = buildActivityMap();
+    List<ActivityMap> list = new ArrayList<>();
+    list.add(activityMap);
     
-    when(mockMBean.getEventActivityMap())
-        .thenReturn(activityMap)
-        .thenReturn(null);
+    when(mockMBean.getEventActivityMaps())
+        .thenReturn(list);
     
     component.init(null);
     component.start();
@@ -64,8 +69,8 @@ public class InterlokProfilerMetricsGeneratorTest {
 
   @Test
   public void testNoMetrics() throws Exception {
-    when(mockMBean.getEventActivityMap())
-        .thenReturn(null);
+    when(mockMBean.getEventActivityMaps())
+        .thenReturn(Collections.emptyList());
     
     component.bindTo(meterRegistry);
     assertEquals(0, meterRegistry.getMeters().size());
@@ -95,11 +100,13 @@ public class InterlokProfilerMetricsGeneratorTest {
   
   @Test
   public void testMultipleMetricsReturns() throws Exception {
-    when(mockMBean.getEventActivityMap())
-        .thenReturn(activityMap)
-        .thenReturn(activityMap)
-        .thenReturn(activityMap)
-        .thenReturn(null);
+    List<ActivityMap> list = new ArrayList<>();
+    list.add(activityMap);
+    list.add(activityMap);
+    list.add(activityMap);
+    
+    when(mockMBean.getEventActivityMaps())
+        .thenReturn(list);
     
     component.bindTo(meterRegistry);
     assertTrue(meterRegistry.getMeters().size() > 0);


### PR DESCRIPTION
## Motivation

Metrics are now retrieved via a list and not repeated calls until you get null.
Put simply this project has a 3 line fix to update to the new model.

## Modification

See InterlokProfilerMetricGenetor; it asks for all metrics timeslices rather than repeatedly calling for the next one.

## Result

Project is now inline with the new way of storing /serving metrics.

