### PR TITLE
INTERLOK-3725 More Metrics

### DIFF
--- a/interlok-rest-metrics-jvm/build.gradle
+++ b/interlok-rest-metrics-jvm/build.gradle
@@ -7,7 +7,8 @@ ext {
 dependencies {
 	compile project(':interlok-rest-base')
 	compile ('io.micrometer:micrometer-registry-prometheus:1.6.3')
-
+	compile ('io.github.mweirauch:micrometer-jvm-extras:0.2.1')
+	
 	testCompile project(':interlok-rest-base').sourceSets.test.output
 }
 

--- a/interlok-rest-metrics-jvm/src/main/java/com/adaptris/rest/metrics/jvm/JvmMetricsGenerator.java
+++ b/interlok-rest-metrics-jvm/src/main/java/com/adaptris/rest/metrics/jvm/JvmMetricsGenerator.java
@@ -1,33 +1,48 @@
 package com.adaptris.rest.metrics.jvm;
 
-import java.lang.management.BufferPoolMXBean;
-import java.lang.management.ClassLoadingMXBean;
-import java.lang.management.CompilationMXBean;
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryPoolMXBean;
-import java.lang.management.MemoryType;
-import java.lang.management.MemoryUsage;
-import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
-import java.util.function.ToLongFunction;
 
 import com.adaptris.core.management.MgmtComponentImpl;
 import com.adaptris.rest.metrics.MetricBinder;
 import com.adaptris.rest.metrics.MetricProviders;
 
-import io.micrometer.core.instrument.FunctionCounter;
-import io.micrometer.core.instrument.Gauge;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmCompilationMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import lombok.Getter;
 
 public class JvmMetricsGenerator extends MgmtComponentImpl implements MetricBinder {
 
+  @Getter
   private final Collection<Tag> tags;
+  
+  private final List<Class<? extends MeterBinder>> meterBinders = Arrays.asList(
+      ClassLoaderMetrics.class,
+      JvmCompilationMetrics.class,
+      JvmGcMetrics.class,
+      JvmHeapPressureMetrics.class,
+      JvmMemoryMetrics.class,
+      JvmThreadMetrics.class,
+      ProcessorMetrics.class,
+      ProcessMemoryMetrics.class,
+      ProcessThreadMetrics.class,
+      FileDescriptorMetrics.class,
+      UptimeMetrics.class);
 
   public JvmMetricsGenerator() {
     this(Collections.emptyList());
@@ -39,123 +54,16 @@ public class JvmMetricsGenerator extends MgmtComponentImpl implements MetricBind
 
   @Override
   public void bindTo(MeterRegistry registry) {
-    for (BufferPoolMXBean bufferPoolBean : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
-      Iterable<Tag> tagsWithId = Tags.concat(tags, "id", bufferPoolBean.getName());
-
-      Gauge.builder("jvm.buffer.count", bufferPoolBean, BufferPoolMXBean::getCount).tags(tagsWithId)
-          .description("An estimate of the number of buffers in the pool").baseUnit(BaseUnits.BUFFERS)
-          .register(registry);
-
-      Gauge.builder("jvm.buffer.memory.used", bufferPoolBean, BufferPoolMXBean::getMemoryUsed).tags(tagsWithId)
-          .description("An estimate of the memory that the Java virtual machine is using for this buffer pool")
-          .baseUnit(BaseUnits.BYTES).register(registry);
-
-      Gauge.builder("jvm.buffer.total.capacity", bufferPoolBean, BufferPoolMXBean::getTotalCapacity).tags(tagsWithId)
-          .description("An estimate of the total capacity of the buffers in this pool").baseUnit(BaseUnits.BYTES)
-          .register(registry);
-    }
-
-    for (MemoryPoolMXBean memoryPoolBean : ManagementFactory.getPlatformMXBeans(MemoryPoolMXBean.class)) {
-      String area = MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap";
-      Iterable<Tag> tagsWithId = Tags.concat(tags, "id", memoryPoolBean.getName(), "area", area);
-
-      Gauge.builder("jvm.memory.used", memoryPoolBean, (mem) -> getUsageValue(mem, MemoryUsage::getUsed))
-          .tags(tagsWithId).description("The amount of used memory").baseUnit(BaseUnits.BYTES).register(registry);
-
-      Gauge.builder("jvm.memory.committed", memoryPoolBean, (mem) -> getUsageValue(mem, MemoryUsage::getCommitted))
-          .tags(tagsWithId)
-          .description("The amount of memory in bytes that is committed for the Java virtual machine to use")
-          .baseUnit(BaseUnits.BYTES).register(registry);
-
-      Gauge.builder("jvm.memory.max", memoryPoolBean, (mem) -> getUsageValue(mem, MemoryUsage::getMax)).tags(tagsWithId)
-          .description("The maximum amount of memory in bytes that can be used for memory management")
-          .baseUnit(BaseUnits.BYTES).register(registry);
-    }
-    
-    ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
-
-    Gauge.builder("jvm.threads.peak", threadBean, ThreadMXBean::getPeakThreadCount)
-            .tags(tags)
-            .description("The peak live thread count since the Java virtual machine started or peak was reset")
-            .baseUnit(BaseUnits.THREADS)
-            .register(registry);
-
-    Gauge.builder("jvm.threads.daemon", threadBean, ThreadMXBean::getDaemonThreadCount)
-            .tags(tags)
-            .description("The current number of live daemon threads")
-            .baseUnit(BaseUnits.THREADS)
-            .register(registry);
-
-    Gauge.builder("jvm.threads.live", threadBean, ThreadMXBean::getThreadCount)
-            .tags(tags)
-            .description("The current number of live threads including both daemon and non-daemon threads")
-            .baseUnit(BaseUnits.THREADS)
-            .register(registry);
-
-    try {
-        threadBean.getAllThreadIds();
-        for (Thread.State state : Thread.State.values()) {
-            Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, state))
-                    .tags(Tags.concat(tags, "state", getStateTagValue(state)))
-                    .description("The current number of threads having " + state + " state")
-                    .baseUnit(BaseUnits.THREADS)
-                    .register(registry);
-        }
-    } catch (Error error) {
-        // An error will be thrown for unsupported operations
-        // e.g. SubstrateVM does not support getAllThreadIds
-    }
-    
-    ClassLoadingMXBean classLoadingBean = ManagementFactory.getClassLoadingMXBean();
-
-    Gauge.builder("jvm.classes.loaded", classLoadingBean, ClassLoadingMXBean::getLoadedClassCount)
-            .tags(tags)
-            .description("The number of classes that are currently loaded in the Java virtual machine")
-            .baseUnit(BaseUnits.CLASSES)
-            .register(registry);
-
-    FunctionCounter.builder("jvm.classes.unloaded", classLoadingBean, ClassLoadingMXBean::getUnloadedClassCount)
-            .tags(tags)
-            .description("The total number of classes unloaded since the Java virtual machine has started execution")
-            .baseUnit(BaseUnits.CLASSES)
-            .register(registry);
-    
-    CompilationMXBean compilationBean = ManagementFactory.getCompilationMXBean();
-    if (compilationBean != null && compilationBean.isCompilationTimeMonitoringSupported()) {
-        FunctionCounter.builder("jvm.compilation.time", compilationBean, CompilationMXBean::getTotalCompilationTime)
-                .tags(Tags.concat(tags, "compiler", compilationBean.getName()))
-                .description("The approximate accumulated elapsed time spent in compilation")
-                .baseUnit(BaseUnits.MILLISECONDS)
-                .register(registry);
-    }
+    meterBinders.forEach( binder -> {
+      try {
+        log.trace("Generating metrics from meter: {}", binder.getSimpleName());
+        binder.getDeclaredConstructor().newInstance().bindTo(registry);
+      } catch (Exception e) {
+        log.warn("Could not collect metrics from binder: {}", binder.getSimpleName(), e);
+      }
+    });
   }
   
-  static long getThreadStateCount(ThreadMXBean threadBean, Thread.State state) {
-    return Arrays.stream(threadBean.getThreadInfo(threadBean.getAllThreadIds()))
-            .filter(threadInfo -> threadInfo != null && threadInfo.getThreadState() == state)
-            .count();
-  }
-
-  private static String getStateTagValue(Thread.State state) {
-    return state.name().toLowerCase().replace("_", "-");
-  }
-
-  static double getUsageValue(MemoryPoolMXBean memoryPoolMXBean, ToLongFunction<MemoryUsage> getter) {
-    MemoryUsage usage = getUsage(memoryPoolMXBean);
-    if (usage == null) {
-      return Double.NaN;
-    }
-    return getter.applyAsLong(usage);
-  }
-
-  private static MemoryUsage getUsage(MemoryPoolMXBean memoryPoolMXBean) {
-    try {
-      return memoryPoolMXBean.getUsage();
-    } catch (InternalError e) {
-      return null;
-    }
-  }
-
   @Override
   public void init(Properties config) throws Exception {
     MetricProviders.addProvider(this);


### PR DESCRIPTION
## Motivation

We're using a standard Grafana dashboard that can display more metrics than we are generating, so for completeness we should be generating these additional metrics (even though very few know the meaning of each metric.  Empty graphs are still empty graphs).

## Modification

The JVM metric generator now uses the standard generators from micrometer and simply has a list of metric binders that we spin through asking each to do their magic.  Quite easy to add new metric binders now too as you'll see.

## Result

We no longer have empty graphs on our Grafana dashboard; we except those that we want to stay empty!

## Testing

Enclosed you'll find a gradle/docker test pack created by MattW that does all the magic.  You'll just need to make sure you use this branch of the metrics jar as opposed to the current 4.0-snap.
Once you've sorted that, crack open Grafana on localhost 3000 and take a look at the JVM stats we're now generating.

[Metric_Testing.zip](https://github.com/adaptris/interlok-workflow-rest-services/files/6043755/Metric_Testing.zip)

