### PR TITLE
INTERLOK-3724 Fixed a bug where only a single workflow was reporting …

### DIFF
--- a/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokMetrics.java
+++ b/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokMetrics.java
@@ -11,7 +11,7 @@ public enum InterlokMetrics {
   WORKFLOW_MESSAGE_COUNT_METRIC ("workflow.count") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddTotalValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddTotalValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -21,7 +21,7 @@ public enum InterlokMetrics {
   WORKFLOW_MESSAGE_FAIL_COUNT_METRIC ("workflow.fail.count") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddTotalValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddTotalValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -31,7 +31,7 @@ public enum InterlokMetrics {
   WORKFLOW_AVG_TIME_NANOS_METRIC ("workflow.avgnanos") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddAvgValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddAvgValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -41,7 +41,7 @@ public enum InterlokMetrics {
   WORKFLOW_AVG_TIME_MILLIS_METRIC ("workflow.avgmillis") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddAvgValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddAvgValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -51,7 +51,7 @@ public enum InterlokMetrics {
   SERVICE_AVG_TIME_NANOS_METRIC ("service.avgnanos") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddAvgValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddAvgValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -61,7 +61,7 @@ public enum InterlokMetrics {
   SERVICE_AVG_TIME_MILLIS_METRIC ("service.avgmillis") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddAvgValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddAvgValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -71,7 +71,7 @@ public enum InterlokMetrics {
   PRODUCER_AVG_TIME_NANOS_METRIC ("producer.avgnanos") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddAvgValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddAvgValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -81,7 +81,7 @@ public enum InterlokMetrics {
   PRODUCER_AVG_TIME_MILLIS_METRIC ("producer.avgmillis") {
     @Override
     public void addMetric(String workflowId, String activityId, Double value, Map<String, MetricHelpTypeAndValue> metricMap) {
-      this.calculateAndAddAvgValue(getMetricName(), metricMap, value, createMetricTags(workflowId, activityId));
+      this.calculateAndAddAvgValue(getMetricName(), workflowId, activityId, metricMap, value, createMetricTags(workflowId, activityId));
     }
 
     @Override
@@ -118,19 +118,19 @@ public enum InterlokMetrics {
     return tags;
   }
   
-  public void calculateAndAddAvgValue(String metricName, Map<String, MetricHelpTypeAndValue> metricMap, Double newValue, Tags tags) {
-    Optional<MetricHelpTypeAndValue> metricHelpTypeValue = Optional.ofNullable(metricMap.get(metricName));
+  public void calculateAndAddAvgValue(String metricName, String workflowId, String activityId, Map<String, MetricHelpTypeAndValue> metricMap, Double newValue, Tags tags) {
+    Optional<MetricHelpTypeAndValue> metricHelpTypeValue = Optional.ofNullable(metricMap.get(metricName + workflowId + activityId));
     metricHelpTypeValue.ifPresent( oldMetricHelpTypeValue -> {
       oldMetricHelpTypeValue.setValue((newValue + oldMetricHelpTypeValue.getValue()) / 2);
     });        
-    metricMap.put(metricName, metricHelpTypeValue.isPresent() ? metricHelpTypeValue.get() : metricHelpTypeValue.orElseGet(() -> new MetricHelpTypeAndValue(getHelp(), newValue, tags)));
+    metricMap.put(metricName + workflowId + activityId, metricHelpTypeValue.isPresent() ? metricHelpTypeValue.get() : metricHelpTypeValue.orElseGet(() -> new MetricHelpTypeAndValue(metricName, getHelp(), newValue, tags)));
   }
   
-  public void calculateAndAddTotalValue(String metricName, Map<String, MetricHelpTypeAndValue> metricMap, Double newValue, Tags tags) {
-    Optional<MetricHelpTypeAndValue> metricHelpTypeValue = Optional.ofNullable(metricMap.get(metricName));
+  public void calculateAndAddTotalValue(String metricName, String workflowId, String activityId, Map<String, MetricHelpTypeAndValue> metricMap, Double newValue, Tags tags) {
+    Optional<MetricHelpTypeAndValue> metricHelpTypeValue = Optional.ofNullable(metricMap.get(metricName + workflowId + activityId));
     metricHelpTypeValue.ifPresent( oldMetricHelpTypeValue -> {
       oldMetricHelpTypeValue.setValue(newValue + oldMetricHelpTypeValue.getValue());
     });        
-    metricMap.put(metricName, metricHelpTypeValue.isPresent() ? metricHelpTypeValue.get() : metricHelpTypeValue.orElseGet(() -> new MetricHelpTypeAndValue(getHelp(), newValue, tags)));
+    metricMap.put(metricName + workflowId + activityId, metricHelpTypeValue.isPresent() ? metricHelpTypeValue.get() : metricHelpTypeValue.orElseGet(() -> new MetricHelpTypeAndValue(metricName, getHelp(), newValue, tags)));
   }
 }

--- a/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGenerator.java
+++ b/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGenerator.java
@@ -99,7 +99,7 @@ public class InterlokProfilerMetricsGenerator extends MgmtComponentImpl implemen
     }
     
     profilingEvents.forEach( (metricName, helpValueTags) -> {
-      Gauge.builder(metricName, helpValueTags, MetricHelpTypeAndValue::getValue)
+      Gauge.builder(helpValueTags.getMetricName(), helpValueTags, MetricHelpTypeAndValue::getValue)
           .tags(helpValueTags.getTags())
           .description(helpValueTags.getHelp())
           .register(registry);
@@ -118,6 +118,10 @@ public class InterlokProfilerMetricsGenerator extends MgmtComponentImpl implemen
   static class MetricHelpTypeAndValue {
     @Getter
     @Setter
+    private String metricName;
+    
+    @Getter
+    @Setter
     private String help;
     
     @Getter
@@ -128,10 +132,11 @@ public class InterlokProfilerMetricsGenerator extends MgmtComponentImpl implemen
     @Setter
     private Tags tags;
     
-    public MetricHelpTypeAndValue(String help, Double value, Tags tags) {
-      this.setHelp(help);
-      this.setValue(value);
-      this.setTags(tags);
+    public MetricHelpTypeAndValue(String metricName, String help, Double value, Tags tags) {
+      setMetricName(metricName);
+      setHelp(help);
+      setValue(value);
+      setTags(tags);
     }
   }
 

--- a/interlok-rest-metrics-profiler/src/test/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGeneratorTest.java
+++ b/interlok-rest-metrics-profiler/src/test/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.rest.metrics.interlok;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -99,6 +100,12 @@ public class InterlokProfilerMetricsGeneratorTest {
   }
   
   @Test
+  public void testMultipleWorkflowMetrics() throws Exception {
+    component.bindTo(meterRegistry);
+    assertTrue(meterRegistry.getMeters().size() > 0);
+  }
+  
+  @Test
   public void testMultipleMetricsReturns() throws Exception {
     List<ActivityMap> list = new ArrayList<>();
     list.add(activityMap);
@@ -109,7 +116,16 @@ public class InterlokProfilerMetricsGeneratorTest {
         .thenReturn(list);
     
     component.bindTo(meterRegistry);
-    assertTrue(meterRegistry.getMeters().size() > 0);
+    
+    assertNotNull(
+        meterRegistry.find("workflow.count")
+            .tag("workflow", "workflow")
+            .gauge());
+    
+    assertNotNull(
+        meterRegistry.find("workflow.count")
+            .tag("workflow", "workflow2")
+            .gauge());
   }
   
   private ActivityMap buildActivityMap() {
@@ -121,6 +137,8 @@ public class InterlokProfilerMetricsGeneratorTest {
     channel.setUniqueId("channel");
     WorkflowActivity workflow = new WorkflowActivity();
     workflow.setUniqueId("workflow");
+    WorkflowActivity workflow2 = new WorkflowActivity();
+    workflow2.setUniqueId("workflow2");
     ProducerActivity producer = new ProducerActivity();
     producer.setUniqueId("producer");
     ConsumerActivity consumer = new ConsumerActivity();
@@ -137,6 +155,7 @@ public class InterlokProfilerMetricsGeneratorTest {
     workflow.getServices().put(service.getUniqueId(), service);
     
     channel.getWorkflows().put(workflow.getUniqueId(), workflow);
+    channel.getWorkflows().put(workflow2.getUniqueId(), workflow2);
     adapter.getChannels().put(channel.getUniqueId(), channel);
     
     map.getAdapters().put(adapter.getUniqueId(), adapter);


### PR DESCRIPTION
## Motivation

A bug was found where only a single workflow was reporting metrics.

## Modification

Essentially the code was using a map to store metric names as the map keys as it builds up data; previously each metric name would have been unique seeing as we were not using tags, now however each metric name is not unique therefore map items were being overriden.  We still use the map, but construct the key from the metric name and the component id.

## Result

Proper functionality is now restored; each workflow will have it's metrics reported.

## Testing

[Metric_Testing.zip](https://github.com/adaptris/interlok-workflow-rest-services/files/6068409/Metric_Testing.zip)

Test pack enclosed.  Simply swap the interlok-rest-metrics-profiler jar out with this one and watch the lovely Grafana graphs go.
