### PR TITLE
INTERLOK-3742

### DIFF
--- a/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/PrometheusEndpointComponent.java
+++ b/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/PrometheusEndpointComponent.java
@@ -43,6 +43,8 @@ public class PrometheusEndpointComponent  extends AbstractRestfulEndpoint {
       
       getConsumer().doResponse(message, message);
       success.accept(message);
+      
+      prometheusRegistry.clear();
     } catch (Exception ex) {
       getConsumer().doErrorResponse(message, ex, ERROR_DEFAULT);
       failure.accept(message);

--- a/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/PrometheusEndpointComponent.java
+++ b/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/PrometheusEndpointComponent.java
@@ -28,12 +28,21 @@ public class PrometheusEndpointComponent  extends AbstractRestfulEndpoint {
   @Getter(AccessLevel.PROTECTED)
   private transient final String acceptedFilter = ACCEPTED_FILTER;
 
-  private transient PrometheusMeterRegistry prometheusRegistry = null;
-
   @Override
   public void onAdaptrisMessage(AdaptrisMessage message, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    PrometheusMeterRegistry prometheusRegistry =
+        new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    prometheusRegistry.config().meterFilter(new PrometheusRenameFilter());
     try {
-      bindProviders();
+      MetricProviders.getProviders().forEach(provider -> {
+        try {
+          provider.bindTo(prometheusRegistry);
+        } catch (Exception e) {
+          // This is wrong, because if we've failed to bind, then we need to try and bind again.
+          log.warn("Metric gathering failed, will try again on next request.");
+          exceptionLogging(ADDITIONAL_DEBUG, "Stack trace from metric gathering failure :", e);
+        }
+      });
       message.setContent(prometheusRegistry.scrape(), message.getContentEncoding());
 
       getConsumer().doResponse(message, message);
@@ -41,6 +50,9 @@ public class PrometheusEndpointComponent  extends AbstractRestfulEndpoint {
     } catch (Exception ex) {
       getConsumer().doErrorResponse(message, ex, ERROR_DEFAULT);
       failure.accept(message);
+    } finally {
+      prometheusRegistry.clear();
+      prometheusRegistry.close();
     }
   }
 
@@ -49,39 +61,5 @@ public class PrometheusEndpointComponent  extends AbstractRestfulEndpoint {
     if (logging) {
       log.trace(msg, e);
     }
-  }
-
-
-  private void bindProviders() {
-    MetricProviders.getProviders().forEach(provider -> {
-      try {
-        provider.bindTo(prometheusRegistry);
-      } catch (Exception e) {
-        // This is wrong, because if we've failed to bind, then we need to try and bind again.
-        log.warn("Metric gathering failed, will try again on next request.");
-        exceptionLogging(ADDITIONAL_DEBUG, "Stack trace from metric gathering failure :", e);
-      }
-    });
-  }
-
-
-  @Override
-  public void start() throws Exception {
-    prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-    prometheusRegistry.config().meterFilter(new PrometheusRenameFilter());
-    super.start();
-  }
-
-  @Override
-  public void stop() throws Exception {
-    prometheusRegistry.clear();
-    super.stop();
-  }
-
-
-  @Override
-  public void destroy() throws Exception {
-    prometheusRegistry.close();
-    super.destroy();
   }
 }

--- a/interlok-rest-provider-prometheus/src/test/java/com/adaptris/rest/PrometheusEndpointComponentTest.java
+++ b/interlok-rest-provider-prometheus/src/test/java/com/adaptris/rest/PrometheusEndpointComponentTest.java
@@ -26,12 +26,14 @@ public class PrometheusEndpointComponentTest {
 
     component = new PrometheusEndpointComponent();
     component.setConsumer(mockConsumer);
-
+    component.start();
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
   }
 
   @After
   public void tearDown() throws Exception {
+    component.stop();
+    component.destroy();
 
   }
 


### PR DESCRIPTION
## Motivation

It looks as though there might be a memory leak somewhere in the profiler code.  From Matt's last heap dumps it suggests that the micrometer registries are growing in size over time.

## Modification

Just in case there is some magic somewhere caching registry meters we now call clear on the newly created registry after we're done with it.  Previously we would simply allow it to be garbage collected.

## Result

Hoping to see the registry no longer growing in size over time.
