### PR TITLE
INTERLOK_3764 We now Tag each metric with the workflow ID.

### DIFF
--- a/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGenerator.java
+++ b/interlok-rest-metrics-profiler/src/main/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGenerator.java
@@ -57,6 +57,7 @@ public class InterlokProfilerMetricsGenerator extends MgmtComponentImpl implemen
     Set<ObjectName> queryMBeans = getJmxMBeanHelper().getMBeanNames(PROFILER_OBJECT_NAME);
     queryMBeans.forEach( object -> {
       TimedThroughputMetricMBean mBean = getJmxMBeanHelper().proxyMBean(object, TimedThroughputMetricMBean.class);
+      // If no workflow ID, then this may be an event or the base workflow rest HTTP acceptor service so ignore.
       if(mBean.getWorkflowId() != null) {
         Counter countCounter = getOrCreateCountMeter(METRIC_COUNT + mBean.getUniqueId(), object, mBean, registry);
         countCounter.increment(mBean.getMessageCount() - countCounter.count());

--- a/interlok-rest-metrics-profiler/src/test/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGeneratorTest.java
+++ b/interlok-rest-metrics-profiler/src/test/java/com/adaptris/rest/metrics/interlok/InterlokProfilerMetricsGeneratorTest.java
@@ -30,7 +30,7 @@ public class InterlokProfilerMetricsGeneratorTest {
 
   @Mock private JmxMBeanHelper mockJmxHelper;
   
-  private TimedThroughputMetric metricMbeanOne, metricMbeanTwo;
+  private TimedThroughputMetric metricMbeanOne, metricMbeanTwo, metricMbeanThree;
   
   private PrometheusMeterRegistry meterRegistry;
 
@@ -40,13 +40,19 @@ public class InterlokProfilerMetricsGeneratorTest {
 
     metricMbeanOne = new TimedThroughputMetric();
     metricMbeanOne.setUniqueId("workflow");
+    metricMbeanOne.setWorkflowId("workflowid");
     
     metricMbeanTwo = new TimedThroughputMetric();
     metricMbeanTwo.setUniqueId("producer");
+    metricMbeanTwo.setWorkflowId("workflowid");
+    
+    metricMbeanThree = new TimedThroughputMetric();
+    metricMbeanThree.setUniqueId("workflow");
     
     Set<ObjectName> metricSet = new HashSet<>();
     ObjectName o1 = new ObjectName("com.adaptris:type=profiler,componentType=workflow,id=1");
     ObjectName o2 = new ObjectName("com.adaptris:type=profiler,componentType=producer,id=2");
+    
     metricSet.add(o1);
     metricSet.add(o2);
     
@@ -77,6 +83,22 @@ public class InterlokProfilerMetricsGeneratorTest {
   public void testNoMetrics() throws Exception {
     when(mockJmxHelper.getMBeanNames(anyString()))
         .thenReturn(Collections.emptySet());
+    
+    component.bindTo(meterRegistry);
+    assertEquals(0, meterRegistry.getMeters().size());
+  }
+  
+  @Test
+  public void testMetricsWithoutWorkflows() throws Exception {
+    Set<ObjectName> metricSet = new HashSet<>();
+    ObjectName o3 = new ObjectName("com.adaptris:type=profiler,componentType=producer,id=2");
+    metricSet.add(o3);
+    
+    when(mockJmxHelper.proxyMBean(o3, TimedThroughputMetricMBean.class))
+        .thenReturn(metricMbeanThree);
+    
+    when(mockJmxHelper.getMBeanNames(anyString()))
+        .thenReturn(metricSet);
     
     component.bindTo(meterRegistry);
     assertEquals(0, meterRegistry.getMeters().size());


### PR DESCRIPTION
## Motivation

We need to tag each components metric with the workflow ID so we can group services/producers belonging to a single workflow into a single graph/chart.

## Modification

The profiler metrics class simply now uses the workflow ID from the Interlok queried MBeans and tags each metric with the workflow ID value.
As an additional benefit we now check to make sure that each component does have a workflow ID; if it doesn't then we can assume the profiled metric MBeans have come from Interlok events or maye even be the components we're using for the REST API.  Basically we only want to write metrics from active workflows and their components.

## PR Checklist

- [x] been self-reviewed.
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

Each metric served or pushed by this component will have a workflow ID tagged to it.

## Testing

Run the profiler with the following managementProperties;
jmx:jetty:metrics-interlok:metrics-provider-prometheus

Make sure you have some activity running through your workflow(s) and then browse to; http://localhost:8080/prometheus/metrics. You'll see a bunch of metrics and for each you'll see the workflow ID tag.
