### PR TITLE
INTERLOK-3781 Repackaging the classes.

### DIFF
--- a/interlok-rest-base/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
+++ b/interlok-rest-base/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
@@ -13,8 +13,8 @@ import lombok.Setter;
 public abstract class AbstractRestfulEndpoint extends MgmtComponentImpl implements AdaptrisMessageListener {
   public static final String MDC_KEY = "ManagementComponent";
 
-  @Getter(AccessLevel.PACKAGE)
-  @Setter(AccessLevel.PACKAGE)
+  @Getter
+  @Setter
   private transient WorkflowServicesConsumer consumer;
 
   @Setter(AccessLevel.PROTECTED)

--- a/interlok-rest-base/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
+++ b/interlok-rest-base/src/main/java/com/adaptris/rest/HttpRestWorkflowServicesConsumer.java
@@ -70,7 +70,7 @@ public class HttpRestWorkflowServicesConsumer extends WorkflowServicesConsumer {
   }
 
   @Override
-  protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
+  public void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
       String contentType, int httpStatus) {
     try {
       processedMessage.addObjectHeader(JettyConstants.JETTY_WRAPPER,

--- a/interlok-rest-base/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
+++ b/interlok-rest-base/src/main/java/com/adaptris/rest/WorkflowServicesConsumer.java
@@ -50,19 +50,19 @@ public abstract class WorkflowServicesConsumer implements ComponentLifecycle, Co
 
   protected abstract StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods);
 
-  protected void doResponse(AdaptrisMessage original, AdaptrisMessage processed) throws ServiceException {
+  public void doResponse(AdaptrisMessage original, AdaptrisMessage processed) throws ServiceException {
     doResponse(original, processed, CONTENT_TYPE_DEFAULT);
   }
 
-  protected void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType)
+  public void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType)
       throws ServiceException {
     doResponse(orig, proc, contentType, OK_200);
   }
 
-  protected abstract void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType,
+  public abstract void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType,
       int httpResponse);
 
-  protected abstract void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus);
+  public abstract void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus);
 
   @Override
   public void prepare() throws CoreException {

--- a/interlok-rest-base/src/test/java/com/adaptris/rest/MockWorkflowConsumer.java
+++ b/interlok-rest-base/src/test/java/com/adaptris/rest/MockWorkflowConsumer.java
@@ -4,11 +4,22 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.StandaloneConsumer;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class MockWorkflowConsumer extends WorkflowServicesConsumer {
 
-  String payload;
-  boolean isError;
-  int httpStatus = -1;
+  @Getter
+  @Setter
+  private String payload;
+  
+  @Getter
+  @Setter
+  private boolean isError;
+  
+  @Getter
+  @Setter
+  private int httpStatus = -1;
 
   @Override
   protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {
@@ -16,7 +27,7 @@ public class MockWorkflowConsumer extends WorkflowServicesConsumer {
   }
 
   @Override
-  protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
+  public void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
       String contentType, int status) {
     payload = processedMessage.getContent();
     httpStatus = status;

--- a/interlok-rest-cluster/src/main/java/com/adaptris/rest/cluster/ClusterManagerComponent.java
+++ b/interlok-rest-cluster/src/main/java/com/adaptris/rest/cluster/ClusterManagerComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.cluster;
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +10,8 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.mgmt.cluster.ClusterInstance;
 import com.adaptris.mgmt.cluster.mbean.ClusterManagerMBean;
+import com.adaptris.rest.AbstractRestfulEndpoint;
+import com.adaptris.rest.HttpRestWorkflowServicesConsumer;
 import com.adaptris.rest.util.JmxMBeanHelper;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/interlok-rest-cluster/src/test/java/com/adaptris/rest/cluster/ClusterManagerComponentTest.java
+++ b/interlok-rest-cluster/src/test/java/com/adaptris/rest/cluster/ClusterManagerComponentTest.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.cluster;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertFalse;
@@ -25,6 +25,7 @@ import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.cache.ExpiringMapCache;
 import com.adaptris.mgmt.cluster.ClusterInstance;
 import com.adaptris.mgmt.cluster.mbean.ClusterManagerMBean;
+import com.adaptris.rest.MockWorkflowConsumer;
 import com.adaptris.rest.util.JmxMBeanHelper;
 
 public class ClusterManagerComponentTest {
@@ -89,7 +90,7 @@ public class ClusterManagerComponentTest {
       .until(testConsumer::complete);
 
     // assert no cluster instances;
-    assertFalse(testConsumer.payload.contains("instance"));
+    assertFalse(testConsumer.getPayload().contains("instance"));
   }
 
   @Test
@@ -105,7 +106,7 @@ public class ClusterManagerComponentTest {
       .until(testConsumer::complete);
 
     @SuppressWarnings("unchecked")
-    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
+    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.getPayload());
 
     assertTrue(instances.size() == 1);
     assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
@@ -127,7 +128,7 @@ public class ClusterManagerComponentTest {
       .until(testConsumer::complete);
 
     @SuppressWarnings("unchecked")
-    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
+    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.getPayload());
 
     assertTrue(instances.size() == 2);
     assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
@@ -152,6 +153,6 @@ public class ClusterManagerComponentTest {
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
 
-    assertTrue(testConsumer.isError);
+    assertTrue(testConsumer.isError());
   }
 }

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.healthcheck;
 
 import static com.adaptris.rest.WorkflowServicesConsumer.CONTENT_TYPE_JSON;
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
@@ -27,10 +27,7 @@ import com.adaptris.core.StartedState;
 import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
-import com.adaptris.rest.healthcheck.AdapterList;
-import com.adaptris.rest.healthcheck.AdapterState;
-import com.adaptris.rest.healthcheck.ChannelState;
-import com.adaptris.rest.healthcheck.WorkflowState;
+import com.adaptris.rest.AbstractRestfulEndpoint;
 import com.adaptris.rest.util.JmxMBeanHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.AccessLevel;

--- a/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
+++ b/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.healthcheck;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,14 +16,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
+
 import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Durations;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.AdaptrisMessageListener;
@@ -33,7 +37,7 @@ import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
 import com.adaptris.core.runtime.AdapterManager;
-import com.adaptris.rest.healthcheck.AdapterState;
+import com.adaptris.rest.WorkflowServicesConsumer;
 import com.adaptris.rest.util.JmxMBeanHelper;
 
 public class WorkflowHealthCheckComponentTest {
@@ -71,7 +75,7 @@ public class WorkflowHealthCheckComponentTest {
     JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
 
-    when(mockJmxHelper.getMBeans(anyString())).thenReturn(Collections.EMPTY_SET);
+    when(mockJmxHelper.getMBeans(anyString())).thenReturn(Collections.emptySet());
     try {
       wrapper.start();
       wrapper.healthCheck().onAdaptrisMessage(message);
@@ -140,7 +144,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -163,7 +166,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -186,7 +188,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check/alive");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -206,7 +207,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -227,7 +227,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -253,7 +252,7 @@ public class WorkflowHealthCheckComponentTest {
     private JmxMBeanHelper mockJmxHelper;
 
     public MockedHealthCheckWrapper() throws Exception {
-      MockitoAnnotations.initMocks(this);
+      MockitoAnnotations.openMocks(this);
     }
 
     public MockedHealthCheckWrapper build(boolean workflowsAreStarted) throws Exception {
@@ -351,7 +350,7 @@ public class WorkflowHealthCheckComponentTest {
     }
 
     @Override
-    protected void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
+    public void doResponse(AdaptrisMessage originalMessage, AdaptrisMessage processedMessage,
         String contentType, int status) {
       payload = processedMessage.getContent();
       httpStatus = status;

--- a/interlok-rest-provider-datadog/src/main/java/com/adaptris/rest/datadog/DatadogPushComponent.java
+++ b/interlok-rest-provider-datadog/src/main/java/com/adaptris/rest/datadog/DatadogPushComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.datadog;
 
 import java.time.Duration;
 import java.util.Properties;

--- a/interlok-rest-provider-datadog/src/test/java/com/adaptris/rest/datadog/DatadogPushComponentTest.java
+++ b/interlok-rest-provider-datadog/src/test/java/com/adaptris/rest/datadog/DatadogPushComponentTest.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.datadog;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -9,6 +9,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.adaptris.rest.datadog.DatadogPushComponent;
 import com.adaptris.rest.metrics.MetricBinder;
 import com.adaptris.rest.metrics.MetricProviders;
 

--- a/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/prometheus/PrometheusEndpointComponent.java
+++ b/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/prometheus/PrometheusEndpointComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.prometheus;
 
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 
@@ -6,6 +6,7 @@ import java.util.Properties;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.rest.AbstractRestfulEndpoint;
 import com.adaptris.rest.metrics.MetricProviders;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;

--- a/interlok-rest-provider-prometheus/src/test/java/com/adaptris/rest/prometheus/PrometheusEndpointComponentTest.java
+++ b/interlok-rest-provider-prometheus/src/test/java/com/adaptris/rest/prometheus/PrometheusEndpointComponentTest.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.prometheus;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -8,10 +8,13 @@ import java.util.Properties;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.rest.MockWorkflowConsumer;
 import com.adaptris.rest.metrics.MetricBinder;
 import com.adaptris.rest.metrics.MetricProviders;
+
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 
@@ -45,8 +48,8 @@ public class PrometheusEndpointComponentTest {
   public void testNoMetrics() throws Exception {
     component.onAdaptrisMessage(message);
 
-    assertFalse(mockConsumer.isError);
-    assertTrue(mockConsumer.payload.equals(""));
+    assertFalse(mockConsumer.isError());
+    assertTrue(mockConsumer.getPayload().equals(""));
   }
 
   @Test
@@ -56,8 +59,8 @@ public class PrometheusEndpointComponentTest {
 
     component.onAdaptrisMessage(message);
 
-    assertFalse(mockConsumer.isError);
-    assertTrue(mockConsumer.payload.contains("test_metric"));
+    assertFalse(mockConsumer.isError());
+    assertTrue(mockConsumer.getPayload().contains("test_metric"));
   }
 
   @Test
@@ -66,16 +69,16 @@ public class PrometheusEndpointComponentTest {
     MetricProviders.getProviders().add(new MockFailingMetricProvider());
     component.onAdaptrisMessage(message);
 
-    assertFalse(mockConsumer.isError);
-    assertTrue(mockConsumer.payload.isEmpty());
+    assertFalse(mockConsumer.isError());
+    assertTrue(mockConsumer.getPayload().isEmpty());
   }
 
   @Test
   public void testErrorResponse() throws Exception {
     component.onAdaptrisMessage(null);
 
-    assertTrue(mockConsumer.isError);
-    assertTrue(mockConsumer.httpStatus == 500);
+    assertTrue(mockConsumer.isError());
+    assertTrue(mockConsumer.getHttpStatus() == 500);
   }
 
   @Test


### PR DESCRIPTION
## Motivation

The sub projects are all using the same package; "com.adaptris.rest".  For future proofing fore modules we should make sure that each sub project has it's own package name.

## Modification

Only the base project is now using "com.adaptris.rest" while the datadog sub project is now using "com.adaptris.rest.datadog".
A few access modifiers have also had to change to facilitate the package moves.

## PR Checklist

- [x] been self-reviewed.

None of these components are configured other than through management components.

## Result

Nothing changes functionally.

## Testing

No testing required other than the unit-tests, which all pass.