### PR TITLE
INTERLOK-3781 Repackaging away from com.adaptris.rest to have sub-pac…

### DIFF
--- a/interlok-rest-base/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
+++ b/interlok-rest-base/src/main/java/com/adaptris/rest/AbstractRestfulEndpoint.java
@@ -1,7 +1,10 @@
 package com.adaptris.rest;
 
+import java.net.HttpURLConnection;
 import java.util.Properties;
 import org.apache.commons.lang3.ObjectUtils;
+
+import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.management.MgmtComponentImpl;
@@ -13,8 +16,8 @@ import lombok.Setter;
 public abstract class AbstractRestfulEndpoint extends MgmtComponentImpl implements AdaptrisMessageListener {
   public static final String MDC_KEY = "ManagementComponent";
 
-  @Getter(AccessLevel.PACKAGE)
-  @Setter(AccessLevel.PACKAGE)
+  @Getter
+  @Setter
   private transient WorkflowServicesConsumer consumer;
 
   @Setter(AccessLevel.PROTECTED)
@@ -45,6 +48,18 @@ public abstract class AbstractRestfulEndpoint extends MgmtComponentImpl implemen
     }).start();
   }
 
+  public void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType, int httpResponse) {
+    getConsumer().doResponse(orig, proc, contentType, httpResponse);
+  }
+
+  public void doResponse(AdaptrisMessage orig, AdaptrisMessage proc, String contentType) {
+    getConsumer().doResponse(orig, proc, contentType, HttpURLConnection.HTTP_OK);
+  }
+  
+  public void doErrorResponse(AdaptrisMessage message, Exception e, int httpStatus) {
+    getConsumer().doErrorResponse(message, e, httpStatus);
+  }
+  
   protected abstract String getAcceptedFilter();
 
   protected abstract String getDefaultUrlPath();

--- a/interlok-rest-base/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
+++ b/interlok-rest-base/src/main/java/com/adaptris/rest/WorkflowServicesComponent.java
@@ -55,6 +55,9 @@ public class WorkflowServicesComponent extends AbstractRestfulEndpoint {
   private static final String OBJECT_PROPERTY_WORKFLOW = "id";
 
   private static final String HTTP_HEADER_HOST = "http.header.Host";
+  
+  private static final String CONTENT_TYPE_DEFAULT = "text/plain";
+  private static final String CONTENT_TYPE_JSON = "application/json";
 
   @Getter(AccessLevel.PACKAGE)
   @Setter(AccessLevel.PACKAGE)
@@ -102,17 +105,17 @@ public class WorkflowServicesComponent extends AbstractRestfulEndpoint {
         SerializableMessage processedMessage = getJmxClient().process(translateTarget, getMessageTranslator().translate(message));
 
         AdaptrisMessage responseMessage = getMessageTranslator().translate(processedMessage);
-        getConsumer().doResponse(message, responseMessage);
+        doResponse(message, responseMessage, CONTENT_TYPE_DEFAULT);
 
       } else { // we'll just return the definition.
         AdaptrisMessage responseMessage = generateDefinitionFile(message.getMetadataValue(HTTP_HEADER_HOST));
-        getConsumer().doResponse(message, responseMessage);
+        doResponse(message, responseMessage, CONTENT_TYPE_JSON);
       }
       onSuccess.accept(message);
 
     } catch (Exception e) {
       log.error("Unable to inject REST message into the workflow.", e);
-      getConsumer().doErrorResponse(message, e, ERROR_BAD_REQUEST);
+      doErrorResponse(message, e, ERROR_BAD_REQUEST);
       onFailure.accept(message);
     } finally {
       MDC.remove(MDC_KEY);

--- a/interlok-rest-base/src/test/java/com/adaptris/rest/MockWorkflowConsumer.java
+++ b/interlok-rest-base/src/test/java/com/adaptris/rest/MockWorkflowConsumer.java
@@ -4,11 +4,20 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.StandaloneConsumer;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class MockWorkflowConsumer extends WorkflowServicesConsumer {
 
-  String payload;
-  boolean isError;
-  int httpStatus = -1;
+  @Getter
+  @Setter
+  private String payload;
+  @Getter
+  @Setter
+  private boolean isError;
+  @Getter
+  @Setter
+  private int httpStatus = -1;
 
   @Override
   protected StandaloneConsumer configureConsumer(AdaptrisMessageListener messageListener, String consumedUrlPath, String acceptedHttpMethods) {

--- a/interlok-rest-base/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
+++ b/interlok-rest-base/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
@@ -3,6 +3,7 @@ package com.adaptris.rest;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -92,7 +93,7 @@ public class WorkflowServicesComponentTest {
     workflowServicesComponent.onAdaptrisMessage(message);
     
     verify(mockJmxClient).process(any(), any());
-    verify(mockConsumer).doResponse(any(), any());
+    verify(mockConsumer).doResponse(any(AdaptrisMessage.class), any(AdaptrisMessage.class), anyString(), anyInt());
   }
 
   @Test

--- a/interlok-rest-base/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
+++ b/interlok-rest-base/src/test/java/com/adaptris/rest/WorkflowServicesComponentTest.java
@@ -60,7 +60,7 @@ public class WorkflowServicesComponentTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
     
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
     returnedMessage = DefaultMessageFactory.getDefaultInstance().newMessage();

--- a/interlok-rest-cluster/src/main/java/com/adaptris/rest/cluster/ClusterManagerComponent.java
+++ b/interlok-rest-cluster/src/main/java/com/adaptris/rest/cluster/ClusterManagerComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.cluster;
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +10,8 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.mgmt.cluster.ClusterInstance;
 import com.adaptris.mgmt.cluster.mbean.ClusterManagerMBean;
+import com.adaptris.rest.AbstractRestfulEndpoint;
+import com.adaptris.rest.HttpRestWorkflowServicesConsumer;
 import com.adaptris.rest.util.JmxMBeanHelper;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -58,11 +60,11 @@ public class ClusterManagerComponent extends AbstractRestfulEndpoint {
       String jsonString = new XStreamJsonMarshaller().marshal(clusterInstances);
       message.setContent(jsonString, message.getContentEncoding());
 
-      getConsumer().doResponse(message, message, HttpRestWorkflowServicesConsumer.CONTENT_TYPE_JSON);
+      doResponse(message, message, HttpRestWorkflowServicesConsumer.CONTENT_TYPE_JSON);
       onSuccess.accept(message);
 
     } catch (Exception ex) {
-      getConsumer().doErrorResponse(message, ex, ERROR_DEFAULT);
+      doErrorResponse(message, ex, ERROR_DEFAULT);
       onFailure.accept(message);
     } finally {
       MDC.remove(MDC_KEY);

--- a/interlok-rest-cluster/src/main/resources/META-INF/com/adaptris/core/management/components/cluster-rest
+++ b/interlok-rest-cluster/src/main/resources/META-INF/com/adaptris/core/management/components/cluster-rest
@@ -1,1 +1,1 @@
-class=com.adaptris.rest.ClusterManagerComponent
+class=com.adaptris.rest.cluster.ClusterManagerComponent

--- a/interlok-rest-cluster/src/test/java/com/adaptris/rest/cluster/ClusterManagerComponentTest.java
+++ b/interlok-rest-cluster/src/test/java/com/adaptris/rest/cluster/ClusterManagerComponentTest.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.cluster;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertFalse;
@@ -25,6 +25,7 @@ import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.cache.ExpiringMapCache;
 import com.adaptris.mgmt.cluster.ClusterInstance;
 import com.adaptris.mgmt.cluster.mbean.ClusterManagerMBean;
+import com.adaptris.rest.MockWorkflowConsumer;
 import com.adaptris.rest.util.JmxMBeanHelper;
 
 public class ClusterManagerComponentTest {
@@ -89,7 +90,7 @@ public class ClusterManagerComponentTest {
       .until(testConsumer::complete);
 
     // assert no cluster instances;
-    assertFalse(testConsumer.payload.contains("instance"));
+    assertFalse(testConsumer.getPayload().contains("instance"));
   }
 
   @Test
@@ -105,7 +106,7 @@ public class ClusterManagerComponentTest {
       .until(testConsumer::complete);
 
     @SuppressWarnings("unchecked")
-    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
+    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.getPayload());
 
     assertTrue(instances.size() == 1);
     assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
@@ -127,7 +128,7 @@ public class ClusterManagerComponentTest {
       .until(testConsumer::complete);
 
     @SuppressWarnings("unchecked")
-    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.payload);
+    List<ClusterInstance> instances = (List<ClusterInstance>) new XStreamJsonMarshaller().unmarshal(testConsumer.getPayload());
 
     assertTrue(instances.size() == 2);
     assertTrue(instances.get(0).getUniqueId().equals(clusterInstanceOne.getUniqueId()));
@@ -152,6 +153,6 @@ public class ClusterManagerComponentTest {
       .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
       .until(testConsumer::complete);
 
-    assertTrue(testConsumer.isError);
+    assertTrue(testConsumer.isError());
   }
 }

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.healthcheck;
 
 import static com.adaptris.rest.WorkflowServicesConsumer.CONTENT_TYPE_JSON;
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
@@ -27,10 +27,7 @@ import com.adaptris.core.StartedState;
 import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
-import com.adaptris.rest.healthcheck.AdapterList;
-import com.adaptris.rest.healthcheck.AdapterState;
-import com.adaptris.rest.healthcheck.ChannelState;
-import com.adaptris.rest.healthcheck.WorkflowState;
+import com.adaptris.rest.AbstractRestfulEndpoint;
 import com.adaptris.rest.util.JmxMBeanHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.AccessLevel;
@@ -142,7 +139,7 @@ public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
     } catch (NotReadyException e) {
       sendPayload(message, String.format("{\"failure\": \"%s\"}", e.getMessage()), ERROR_NOT_READY);
     } catch (Exception e) {
-      getConsumer().doErrorResponse(message, e, ERROR_DEFAULT);
+      doErrorResponse(message, e, ERROR_DEFAULT);
       onFailure.accept(message);
     } finally {
       MDC.remove(MDC_KEY);
@@ -153,7 +150,7 @@ public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
   private void sendPayload(AdaptrisMessage message, String newPayload, int httpStatus) {
     // Since JSON should always be UTF-8
     message.setContent(newPayload, StandardCharsets.UTF_8.name());
-    getConsumer().doResponse(message, message, CONTENT_TYPE_JSON, httpStatus);
+    doResponse(message, message, CONTENT_TYPE_JSON, httpStatus);
   }
 
   private void sendPayload(AdaptrisMessage message, Optional<List<AdapterState>> optState) {

--- a/interlok-rest-health-check/src/main/resources/META-INF/com/adaptris/core/management/components/health-check
+++ b/interlok-rest-health-check/src/main/resources/META-INF/com/adaptris/core/management/components/health-check
@@ -1,1 +1,1 @@
-class=com.adaptris.rest.WorkflowHealthCheckComponent
+class=com.adaptris.rest.healthcheck.WorkflowHealthCheckComponent

--- a/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
+++ b/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.healthcheck;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,14 +16,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
+
 import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Durations;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.AdaptrisMessageListener;
@@ -33,7 +37,7 @@ import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
 import com.adaptris.core.runtime.AdapterManager;
-import com.adaptris.rest.healthcheck.AdapterState;
+import com.adaptris.rest.WorkflowServicesConsumer;
 import com.adaptris.rest.util.JmxMBeanHelper;
 
 public class WorkflowHealthCheckComponentTest {
@@ -71,7 +75,7 @@ public class WorkflowHealthCheckComponentTest {
     JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
 
-    when(mockJmxHelper.getMBeans(anyString())).thenReturn(Collections.EMPTY_SET);
+    when(mockJmxHelper.getMBeans(anyString())).thenReturn(Collections.emptySet());
     try {
       wrapper.start();
       wrapper.healthCheck().onAdaptrisMessage(message);
@@ -140,7 +144,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -163,7 +166,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -186,7 +188,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check/alive");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -206,7 +207,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(false);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -227,7 +227,6 @@ public class WorkflowHealthCheckComponentTest {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
-    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     TestConsumer testConsumer = wrapper.testConsumer();
     try {
       wrapper.start();
@@ -253,7 +252,7 @@ public class WorkflowHealthCheckComponentTest {
     private JmxMBeanHelper mockJmxHelper;
 
     public MockedHealthCheckWrapper() throws Exception {
-      MockitoAnnotations.initMocks(this);
+      MockitoAnnotations.openMocks(this);
     }
 
     public MockedHealthCheckWrapper build(boolean workflowsAreStarted) throws Exception {

--- a/interlok-rest-provider-datadog/src/main/java/com/adaptris/rest/metrics/datadog/DatadogPushComponent.java
+++ b/interlok-rest-provider-datadog/src/main/java/com/adaptris/rest/metrics/datadog/DatadogPushComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.metrics.datadog;
 
 import java.time.Duration;
 import java.util.Properties;

--- a/interlok-rest-provider-datadog/src/main/resources/META-INF/com/adaptris/core/management/components/metrics-provider-datadog
+++ b/interlok-rest-provider-datadog/src/main/resources/META-INF/com/adaptris/core/management/components/metrics-provider-datadog
@@ -1,1 +1,1 @@
-class=com.adaptris.rest.DatadogPushComponent
+class=com.adaptris.rest.metrics.datadog.DatadogPushComponent

--- a/interlok-rest-provider-datadog/src/test/java/com/adaptris/rest/metrics/datadog/DatadogPushComponentTest.java
+++ b/interlok-rest-provider-datadog/src/test/java/com/adaptris/rest/metrics/datadog/DatadogPushComponentTest.java
@@ -1,52 +1,67 @@
-package com.adaptris.rest;
+package com.adaptris.rest.metrics.datadog;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.DefaultMessageFactory;
+
 import com.adaptris.rest.metrics.MetricBinder;
 import com.adaptris.rest.metrics.MetricProviders;
+
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class PrometheusEndpointComponentTest {
+public class DatadogPushComponentTest {
 
-  private PrometheusEndpointComponent component;
-
-  private AdaptrisMessage message;
-
-  private MockWorkflowConsumer mockConsumer;
+  private DatadogPushComponent component;
+  
+  private Properties properties;
 
   @Before
   public void setUp() throws Exception {
-    mockConsumer = new MockWorkflowConsumer();
-
-    component = new PrometheusEndpointComponent();
-    component.setConsumer(mockConsumer);
-    component.init(new Properties());
-    component.start();
-    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    properties = new Properties();
+    properties.put("datadogPushTimerSeconds", "1");
+    properties.put("datadogUrlKey", "http://localhost:5000");
+    properties.put("datadogApiKey", "my-api-key");
+    
+    component = new DatadogPushComponent();
+    component.init(properties);
   }
 
   @After
   public void tearDown() throws Exception {
-    component.stop();
     component.destroy();
-
   }
 
   @Test
+  public void testDefaultsNoApiKey() throws Exception {
+    try {
+      component.init(new Properties());
+      fail("No API key, exception expected.");
+    } catch (Exception ex) {
+      //expected
+    }
+  }
+  
+  @Test
+  public void testDefaultsWithApiKey() throws Exception {
+    properties = new Properties();
+    properties.put("datadogApiKey", "my-api-key");
+    
+    component.init(properties);
+  }
+  
+  @Test
   public void testNoMetrics() throws Exception {
-    component.onAdaptrisMessage(message);
-
-    assertFalse(mockConsumer.isError);
-    assertTrue(mockConsumer.payload.equals(""));
+    component.start();
+    Thread.sleep(1500);
+    component.stop();
+    
+    assertEquals(0, component.getDatadogRegistry().getMeters().size());
   }
 
   @Test
@@ -54,28 +69,22 @@ public class PrometheusEndpointComponentTest {
     MetricProviders.getProviders().clear();
     MetricProviders.getProviders().add(new MockMetricProvider());
 
-    component.onAdaptrisMessage(message);
-
-    assertFalse(mockConsumer.isError);
-    assertTrue(mockConsumer.payload.contains("test_metric"));
+    component.start();
+    Thread.sleep(1500);
+    component.stop();
+    
+    assertEquals(1, component.getDatadogRegistry().getMeters().size());
   }
 
   @Test
-  public void testErrorResponseOnMetricGenerationException() throws Exception {
+  public void testErrorOnMetricBind() throws Exception {
     MetricProviders.getProviders().clear();
     MetricProviders.getProviders().add(new MockFailingMetricProvider());
-    component.onAdaptrisMessage(message);
-
-    assertFalse(mockConsumer.isError);
-    assertTrue(mockConsumer.payload.isEmpty());
-  }
-
-  @Test
-  public void testErrorResponse() throws Exception {
-    component.onAdaptrisMessage(null);
-
-    assertTrue(mockConsumer.isError);
-    assertTrue(mockConsumer.httpStatus == 500);
+    component.start();
+    Thread.sleep(1500);
+    component.stop();
+    
+    assertEquals(0, component.getDatadogRegistry().getMeters().size());
   }
 
   @Test

--- a/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/metrics/prometheus/PrometheusEndpointComponent.java
+++ b/interlok-rest-provider-prometheus/src/main/java/com/adaptris/rest/metrics/prometheus/PrometheusEndpointComponent.java
@@ -1,4 +1,4 @@
-package com.adaptris.rest;
+package com.adaptris.rest.metrics.prometheus;
 
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 
@@ -6,6 +6,7 @@ import java.util.Properties;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.rest.AbstractRestfulEndpoint;
 import com.adaptris.rest.metrics.MetricProviders;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
@@ -20,6 +21,8 @@ public class PrometheusEndpointComponent  extends AbstractRestfulEndpoint {
   private static final String ACCEPTED_FILTER = "GET";
 
   private static final String DEFAULT_PATH = "/prometheus/metrics/*";
+  
+  private static final String CONTENT_TYPE_DEFAULT = "text/plain";
 
   private static final transient boolean ADDITIONAL_DEBUG =
       BooleanUtils.toBoolean(System.getProperty("interlok.prometheus.debug", "false"));
@@ -57,10 +60,10 @@ public class PrometheusEndpointComponent  extends AbstractRestfulEndpoint {
       });
       message.setContent(prometheusRegistry.scrape(), message.getContentEncoding());
 
-      getConsumer().doResponse(message, message);
+      doResponse(message, message, CONTENT_TYPE_DEFAULT);
       success.accept(message);
     } catch (Exception ex) {
-      getConsumer().doErrorResponse(message, ex, ERROR_DEFAULT);
+      doErrorResponse(message, ex, ERROR_DEFAULT);
       failure.accept(message);
     }
   }

--- a/interlok-rest-provider-prometheus/src/main/resources/META-INF/com/adaptris/core/management/components/metrics-provider-prometheus
+++ b/interlok-rest-provider-prometheus/src/main/resources/META-INF/com/adaptris/core/management/components/metrics-provider-prometheus
@@ -1,1 +1,1 @@
-class=com.adaptris.rest.PrometheusEndpointComponent
+class=com.adaptris.rest.metrics.prometheus.PrometheusEndpointComponent


### PR DESCRIPTION
## Motivation

For future packaging/modules we need to make sure the sub projects each have their code in a sub package of com.adaptris.rest and not simply reuse that base package.

## Modification

A couple of small changes to access modifiers such that package private access isn't broken considering all sub classes of AbstractRestfulEndpoint are now in separate packages.

We've also had to change the management component service locator files to point to the new packages.

