### PR TITLE
Include connection health in health check

### DIFF
--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/AdapterState.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/AdapterState.java
@@ -19,8 +19,17 @@ public class AdapterState extends State {
   @Setter
   private List<ChannelState> channelStates;
 
+  @Getter
+  @Setter
+  private List<ConnectionState> connectionStates;
+
   public AdapterState withChannelStates(List<ChannelState> states) {
     setChannelStates(states);
+    return this;
+  }
+
+  public AdapterState withConnectionStates(List<ConnectionState> states) {
+    setConnectionStates(states);
     return this;
   }
 
@@ -29,6 +38,13 @@ public class AdapterState extends State {
       return withChannelStates(new ArrayList<>()).getChannelStates();
     }
     return getChannelStates();
+  }
+
+  public List<ConnectionState> applyConnectionDefaultIfNull() {
+    if (getConnectionStates() == null) {
+      return withConnectionStates(new ArrayList<>()).getConnectionStates();
+    }
+    return getConnectionStates();
   }
 
 }

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/ConnectionState.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/ConnectionState.java
@@ -1,0 +1,31 @@
+package com.adaptris.rest.healthcheck;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@XStreamAlias("connection-state")
+@NoArgsConstructor
+public class ConnectionState extends State {
+
+	@Getter
+	@Setter
+	private String parentType;
+
+	@Getter
+	@Setter
+	private String parentId;
+
+	public ConnectionState withParentType(String parentType) {
+		setParentType(parentType);
+		return this;
+	}
+
+	public ConnectionState withParentId(String parentId) {
+		setParentId(parentId);
+		return this;
+	}
+
+}

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/ConnectionState.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/ConnectionState.java
@@ -10,22 +10,22 @@ import lombok.Setter;
 @NoArgsConstructor
 public class ConnectionState extends State {
 
-	@Getter
-	@Setter
-	private String parentType;
+  @Getter
+  @Setter
+  private String parentType;
 
-	@Getter
-	@Setter
-	private String parentId;
+  @Getter
+  @Setter
+  private String parentId;
 
-	public ConnectionState withParentType(String parentType) {
-		setParentType(parentType);
-		return this;
-	}
+  public ConnectionState withParentType(String parentType) {
+    setParentType(parentType);
+    return this;
+  }
 
-	public ConnectionState withParentId(String parentId) {
-		setParentId(parentId);
-		return this;
-	}
+  public ConnectionState withParentId(String parentId) {
+    setParentId(parentId);
+    return this;
+  }
 
 }

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
@@ -1,5 +1,10 @@
 package com.adaptris.rest.healthcheck;
 
+import static com.adaptris.rest.WorkflowServicesConsumer.CONTENT_TYPE_JSON;
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_NOT_READY;
+import static com.adaptris.rest.WorkflowServicesConsumer.OK_200;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,11 +33,6 @@ import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
 import com.adaptris.rest.AbstractRestfulEndpoint;
-
-import static com.adaptris.rest.WorkflowServicesConsumer.CONTENT_TYPE_JSON;
-import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
-import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_NOT_READY;
-import static com.adaptris.rest.WorkflowServicesConsumer.OK_200;
 
 import com.adaptris.rest.util.JmxMBeanHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
@@ -1,10 +1,5 @@
 package com.adaptris.rest.healthcheck;
 
-import static com.adaptris.rest.WorkflowServicesConsumer.CONTENT_TYPE_JSON;
-import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
-import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_NOT_READY;
-import static com.adaptris.rest.WorkflowServicesConsumer.OK_200;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +28,10 @@ import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
 import com.adaptris.rest.AbstractRestfulEndpoint;
+import static com.adaptris.rest.WorkflowServicesConsumer.CONTENT_TYPE_JSON;
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
+import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_NOT_READY;
+import static com.adaptris.rest.WorkflowServicesConsumer.OK_200;
 import com.adaptris.rest.util.JmxMBeanHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -45,6 +44,7 @@ import lombok.SneakyThrows;
 public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
 
   private static final String BOOTSTRAP_PATH_KEY = "rest.health-check.path";
+  private static final String BOOTSTRAP_CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
 
   private static final String ACCEPTED_FILTER = "GET";
 
@@ -53,11 +53,19 @@ public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
   private static final String ADAPTER_OBJ_TYPE_WILD = "com.adaptris:type=Adapter,*";
 
   private static final String UNIQUE_ID = "UniqueId";
+  private static final String ID_KEY = "id";
 
   private static final String CHILDREN_ATTRIBUTE = "Children";
+  private static final String CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE = "ChildRuntimeInfoComponents";
+  private static final String TYPE_KEY = "type";
+  private static final String CONNECTION_TYPE = "Connection";
+  private static final String WORKFLOW_TYPE = "Workflow";
+  private static final String PARENT_TYPE_ADAPTER = "adapter";
+  private static final String PARENT_TYPE_CHANNEL = "channel";
+  private static final String PARENT_TYPE_WORKFLOW = "workflow";
 
   private static final String COMPONENT_STATE = "ComponentState";
-  
+
   private static final String AUTO_START = "AutoStart";
 
   private static final String PATH_KEY = JettyConstants.JETTY_URI;
@@ -87,6 +95,10 @@ public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
 
   @Getter(AccessLevel.PROTECTED)
   private transient final String defaultUrlPath = DEFAULT_PATH;
+
+  @Getter(AccessLevel.PACKAGE)
+  @Setter(AccessLevel.PACKAGE)
+  private transient boolean checkConnectionHealth = false;
 
   // maps the jettyURI metadata value into its appropriate behaviour.
   private final Map<String, RequestHandler> urlRoutes;
@@ -175,6 +187,10 @@ public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
     verifyReady(id, stateStr, handler);
     Set<ObjectName> channels = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
     addChannelStates(report, channels, handler);
+    if (isCheckConnectionHealth()) {
+      Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+      addConnectionStates(report, connections, handler, PARENT_TYPE_ADAPTER, id);
+    }
     return report;
   }
 
@@ -188,21 +204,52 @@ public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
       ChannelState report = new ChannelState().withId(id).withState(stateStr);
       if(autoStart) { // ignore channels and their children if not auto-start=true
         verifyReady(id, stateStr, handler);
+        if (isCheckConnectionHealth()) {
+          Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+          addConnectionStates(adapterState, connections, handler, PARENT_TYPE_CHANNEL, id);
+        }
         Set<ObjectName> workflows = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
-        addWorkflowStates(report, workflows, handler);
+        addWorkflowStates(adapterState, report, workflows, handler);
         adapterState.applyDefaultIfNull().add(report);
       }
     }
   }
 
-  private void addWorkflowStates(ChannelState channelState, Set<ObjectName> namedWorkflows, IfNotReady handler) throws Exception {
+  private void addWorkflowStates(AdapterState adapterState, ChannelState channelState, Set<ObjectName> namedWorkflows,
+      IfNotReady handler) throws Exception {
     for (ObjectName workflow : namedWorkflows) {
+      // Channel children can include runtime info components (for example connection monitors).
+      // Only workflow ObjectNames should be processed in this block.
+      if (!WORKFLOW_TYPE.equals(workflow.getKeyProperty(TYPE_KEY))) {
+        continue;
+      }
       String objRef = workflow.toString();
       String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
       String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
       WorkflowState report = new WorkflowState().withId(id).withState(stateStr);
       verifyReady(id, stateStr, handler);
+      if (isCheckConnectionHealth()) {
+        Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+        addConnectionStates(adapterState, connections, handler, PARENT_TYPE_WORKFLOW, id);
+      }
       channelState.applyDefaultIfNull().add(report);
+    }
+  }
+
+  private void addConnectionStates(AdapterState adapterState, Set<ObjectName> connections, IfNotReady handler, String parentType,
+      String parentId) throws Exception {
+    for (ObjectName connectionName : connections) {
+      if (!CONNECTION_TYPE.equals(connectionName.getKeyProperty(TYPE_KEY))) {
+        continue;
+      }
+      String objRef = connectionName.toString();
+      String id = connectionName.getKeyProperty(ID_KEY);
+      String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+      ConnectionState report = new ConnectionState();
+      report.withId(id).withState(stateStr);
+      report.withParentType(parentType).withParentId(parentId);
+      verifyReady(id, stateStr, handler);
+      adapterState.applyConnectionDefaultIfNull().add(report);
     }
   }
 
@@ -218,6 +265,7 @@ public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
   public void init(Properties config) throws Exception {
     super.init(config);
     setConfiguredUrlPath(config.getProperty(BOOTSTRAP_PATH_KEY));
+    setCheckConnectionHealth(BooleanUtils.toBoolean(config.getProperty(BOOTSTRAP_CONNECTION_CHECK_KEY)));
   }
 
   // What to do if the component isn't ready.

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
@@ -44,251 +44,251 @@ import lombok.SneakyThrows;
 @XStreamAlias("health-check")
 public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
 
-    private static final String BOOTSTRAP_PATH_KEY = "rest.health-check.path";
-    private static final String BOOTSTRAP_CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
+  private static final String BOOTSTRAP_PATH_KEY = "rest.health-check.path";
+  private static final String BOOTSTRAP_CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
 
-    private static final String ACCEPTED_FILTER = "GET";
+  private static final String ACCEPTED_FILTER = "GET";
 
-    private static final String DEFAULT_PATH = "/workflow-health-check/*";
+  private static final String DEFAULT_PATH = "/workflow-health-check/*";
 
-    private static final String ADAPTER_OBJ_TYPE_WILD = "com.adaptris:type=Adapter,*";
+  private static final String ADAPTER_OBJ_TYPE_WILD = "com.adaptris:type=Adapter,*";
 
-    private static final String UNIQUE_ID = "UniqueId";
-    private static final String ID_KEY = "id";
+  private static final String UNIQUE_ID = "UniqueId";
+  private static final String ID_KEY = "id";
 
-    private static final String CHILDREN_ATTRIBUTE = "Children";
-    private static final String CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE = "ChildRuntimeInfoComponents";
-    private static final String TYPE_KEY = "type";
-    private static final String CONNECTION_TYPE = "Connection";
-    private static final String WORKFLOW_TYPE = "Workflow";
-    private static final String PARENT_TYPE_ADAPTER = "adapter";
-    private static final String PARENT_TYPE_CHANNEL = "channel";
-    private static final String PARENT_TYPE_WORKFLOW = "workflow";
+  private static final String CHILDREN_ATTRIBUTE = "Children";
+  private static final String CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE = "ChildRuntimeInfoComponents";
+  private static final String TYPE_KEY = "type";
+  private static final String CONNECTION_TYPE = "Connection";
+  private static final String WORKFLOW_TYPE = "Workflow";
+  private static final String PARENT_TYPE_ADAPTER = "adapter";
+  private static final String PARENT_TYPE_CHANNEL = "channel";
+  private static final String PARENT_TYPE_WORKFLOW = "workflow";
 
-    private static final String COMPONENT_STATE = "ComponentState";
+  private static final String COMPONENT_STATE = "ComponentState";
+  
+  private static final String AUTO_START = "AutoStart";
 
-    private static final String AUTO_START = "AutoStart";
+  private static final String PATH_KEY = JettyConstants.JETTY_URI;
 
-    private static final String PATH_KEY = JettyConstants.JETTY_URI;
+  private static final String LIVENESS_URL = "^.*/alive$";
+  private static final String READINESS_URL = "^.*/ready$";
+  private static final String DEFAULT_URL = "^.*$";
 
-    private static final String LIVENESS_URL = "^.*/alive$";
-    private static final String READINESS_URL = "^.*/ready$";
-    private static final String DEFAULT_URL = "^.*$";
+  private static final List<String> URL_PATTERNS = Collections.unmodifiableList(Arrays.asList(LIVENESS_URL, READINESS_URL, DEFAULT_URL));
 
-    private static final List<String> URL_PATTERNS = Collections.unmodifiableList(Arrays.asList(LIVENESS_URL, READINESS_URL, DEFAULT_URL));
+  // mapping "StartedState" -> StartedState.getInstance()
+  private static final List<ComponentState> STATE_LIST = Collections.unmodifiableList(
+      Arrays.asList(StoppedState.getInstance(), InitialisedState.getInstance(), StartedState.getInstance(), ClosedState.getInstance()));
 
-    // mapping "StartedState" -> StartedState.getInstance()
-    private static final List<ComponentState> STATE_LIST = Collections.unmodifiableList(
-            Arrays.asList(StoppedState.getInstance(), InitialisedState.getInstance(), StartedState.getInstance(), ClosedState.getInstance()));
+  private static final Map<String, ComponentState> NAME_TO_COMPONENT_STATE = Collections
+      .unmodifiableMap(STATE_LIST.stream().collect(Collectors.toMap((s) -> s.getClass().getSimpleName(), s -> s)));
 
-    private static final Map<String, ComponentState> NAME_TO_COMPONENT_STATE = Collections
-            .unmodifiableMap(STATE_LIST.stream().collect(Collectors.toMap((s) -> s.getClass().getSimpleName(), s -> s)));
+  @Getter(AccessLevel.PACKAGE)
+  @Setter(AccessLevel.PACKAGE)
+  private transient JmxMBeanHelper jmxMBeanHelper;
 
-    @Getter(AccessLevel.PACKAGE)
-    @Setter(AccessLevel.PACKAGE)
-    private transient JmxMBeanHelper jmxMBeanHelper;
+  @Setter(AccessLevel.PACKAGE)
+  private transient XStreamJsonMarshaller marshaller = null;
 
-    @Setter(AccessLevel.PACKAGE)
-    private transient XStreamJsonMarshaller marshaller = null;
+  @Getter(AccessLevel.PROTECTED)
+  private transient final String acceptedFilter = ACCEPTED_FILTER;
 
-    @Getter(AccessLevel.PROTECTED)
-    private transient final String acceptedFilter = ACCEPTED_FILTER;
+  @Getter(AccessLevel.PROTECTED)
+  private transient final String defaultUrlPath = DEFAULT_PATH;
 
-    @Getter(AccessLevel.PROTECTED)
-    private transient final String defaultUrlPath = DEFAULT_PATH;
+  @Getter(AccessLevel.PACKAGE)
+  @Setter(AccessLevel.PACKAGE)
+  private transient boolean checkConnectionHealth = false;
 
-    @Getter(AccessLevel.PACKAGE)
-    @Setter(AccessLevel.PACKAGE)
-    private transient boolean checkConnectionHealth = false;
+  // maps the jettyURI metadata value into its appropriate behaviour.
+  private final Map<String, RequestHandler> urlRoutes;
 
-    // maps the jettyURI metadata value into its appropriate behaviour.
-    private final Map<String, RequestHandler> urlRoutes;
+  public WorkflowHealthCheckComponent() {
+    super();
+    marshaller = new XStreamJsonMarshaller();
+    setJmxMBeanHelper(new JmxMBeanHelper());
+    urlRoutes = buildRoutes();
+  }
 
-    public WorkflowHealthCheckComponent() {
-        super();
-        marshaller = new XStreamJsonMarshaller();
-        setJmxMBeanHelper(new JmxMBeanHelper());
-        urlRoutes = buildRoutes();
+  // Build the behaviour associated with each "branch" that is possible.
+  private Map<String, RequestHandler> buildRoutes() {
+    Map<String, RequestHandler> routes = new HashMap<>();
+    routes.put(LIVENESS_URL, (msg) -> {
+      // We are alive, because we got here, so just return a blank payload.
+      sendPayload(msg, Optional.empty());
+    });
+    routes.put(READINESS_URL, (msg) -> {
+      // ready means we need to check all the states, and if something isn't started we return a 503
+      buildAdapterStates((id, component) -> {
+        throw new NotReadyException(id + " is not started");
+      });
+      sendPayload(msg, Optional.empty());
+    });
+    routes.put(DEFAULT_URL, (msg) -> {
+      // otherwise we just get the list of states, and report on them.
+      List<AdapterState> states = buildAdapterStates((id, component) -> {
+      });
+      sendPayload(msg, Optional.of(states));
+    });
+    return routes;
+  }
+
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage message, Consumer<AdaptrisMessage> onSuccess, Consumer<AdaptrisMessage> onFailure) {
+    // this is arguably redundant because it's added in the consumer...
+    MDC.put(MDC_KEY, friendlyName());
+    String pathValue = message.getMetadataValue(PATH_KEY);
+    try {
+      // DEFAULT_BRANCH should always match, so if get() throws an exception
+      // then we're in an error state anyway.
+      RequestHandler handler = URL_PATTERNS.stream().filter((s) -> pathValue.matches(s)).findFirst().map((s) -> urlRoutes.get(s)).get();
+      handler.handle(message);
+      onSuccess.accept(message);
+    } catch (NotReadyException e) {
+      sendPayload(message, String.format("{\"failure\": \"%s\"}", e.getMessage()), ERROR_NOT_READY);
+    } catch (Exception e) {
+      doErrorResponse(message, e, ERROR_DEFAULT);
+      onFailure.accept(message);
+    } finally {
+      MDC.remove(MDC_KEY);
     }
+  }
 
-    // Build the behaviour associated with each "branch" that is possible.
-    private Map<String, RequestHandler> buildRoutes() {
-        Map<String, RequestHandler> routes = new HashMap<>();
-        routes.put(LIVENESS_URL, (msg) -> {
-            // We are alive, because we got here, so just return a blank payload.
-            sendPayload(msg, Optional.empty());
-        });
-        routes.put(READINESS_URL, (msg) -> {
-            // ready means we need to check all the states, and if something isn't started we return a 503
-            buildAdapterStates((id, component) -> {
-                throw new NotReadyException(id + " is not started");
-            });
-            sendPayload(msg, Optional.empty());
-        });
-        routes.put(DEFAULT_URL, (msg) -> {
-            // otherwise we just get the list of states, and report on them.
-            List<AdapterState> states = buildAdapterStates((id, component) -> {
-            });
-            sendPayload(msg, Optional.of(states));
-        });
-        return routes;
+  private void sendPayload(AdaptrisMessage message, String newPayload, int httpStatus) {
+    // Since JSON should always be UTF-8
+    message.setContent(newPayload, StandardCharsets.UTF_8.name());
+    doResponse(message, message, CONTENT_TYPE_JSON, httpStatus);
+  }
+
+  private void sendPayload(AdaptrisMessage message, Optional<List<AdapterState>> optState) {
+    String newPayload = optState.map((s) -> toString(s)).orElse("");
+    sendPayload(message, newPayload, OK_200);
+  }
+
+  @SneakyThrows
+  protected String toString(List<AdapterState> states) {
+    return marshaller.marshal(AdapterList.wrap(states));
+  }
+
+  private List<AdapterState> buildAdapterStates(IfNotReady handler) throws Exception {
+    List<AdapterState> states = new ArrayList<>();
+    Set<ObjectInstance> adapterMBeans = getJmxMBeanHelper().getMBeans(ADAPTER_OBJ_TYPE_WILD);
+    for (ObjectInstance adapterMBean : adapterMBeans) {
+      states.add(buildAdapterState(adapterMBean, handler));
     }
+    return states;
+  }
 
-    @Override
-    public void onAdaptrisMessage(AdaptrisMessage message, Consumer<AdaptrisMessage> onSuccess, Consumer<AdaptrisMessage> onFailure) {
-        // this is arguably redundant because it's added in the consumer...
-        MDC.put(MDC_KEY, friendlyName());
-        String pathValue = message.getMetadataValue(PATH_KEY);
-        try {
-            // DEFAULT_BRANCH should always match, so if get() throws an exception
-            // then we're in an error state anyway.
-            RequestHandler handler = URL_PATTERNS.stream().filter((s) -> pathValue.matches(s)).findFirst().map((s) -> urlRoutes.get(s)).get();
-            handler.handle(message);
-            onSuccess.accept(message);
-        } catch (NotReadyException e) {
-            sendPayload(message, String.format("{\"failure\": \"%s\"}", e.getMessage()), ERROR_NOT_READY);
-        } catch (Exception e) {
-            doErrorResponse(message, e, ERROR_DEFAULT);
-            onFailure.accept(message);
-        } finally {
-            MDC.remove(MDC_KEY);
-        }
+  private AdapterState buildAdapterState(ObjectInstance mbean, IfNotReady handler) throws Exception {
+    String objRef = mbean.getObjectName().toString();
+    String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
+    String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+    AdapterState report = new AdapterState().withId(id).withState(stateStr);
+    verifyReady(id, stateStr, handler);
+    Set<ObjectName> channels = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
+    addChannelStates(report, channels, handler);
+    if (isCheckConnectionHealth()) {
+      Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+      addConnectionStates(report, connections, handler, PARENT_TYPE_ADAPTER, id);
     }
+    return report;
+  }
 
-    private void sendPayload(AdaptrisMessage message, String newPayload, int httpStatus) {
-        // Since JSON should always be UTF-8
-        message.setContent(newPayload, StandardCharsets.UTF_8.name());
-        doResponse(message, message, CONTENT_TYPE_JSON, httpStatus);
-    }
+  private void addChannelStates(AdapterState adapterState, Set<ObjectName> namedChannels, IfNotReady handler) throws Exception {
 
-    private void sendPayload(AdaptrisMessage message, Optional<List<AdapterState>> optState) {
-        String newPayload = optState.map((s) -> toString(s)).orElse("");
-        sendPayload(message, newPayload, OK_200);
-    }
-
-    @SneakyThrows
-    protected String toString(List<AdapterState> states) {
-        return marshaller.marshal(AdapterList.wrap(states));
-    }
-
-    private List<AdapterState> buildAdapterStates(IfNotReady handler) throws Exception {
-        List<AdapterState> states = new ArrayList<>();
-        Set<ObjectInstance> adapterMBeans = getJmxMBeanHelper().getMBeans(ADAPTER_OBJ_TYPE_WILD);
-        for (ObjectInstance adapterMBean : adapterMBeans) {
-            states.add(buildAdapterState(adapterMBean, handler));
-        }
-        return states;
-    }
-
-    private AdapterState buildAdapterState(ObjectInstance mbean, IfNotReady handler) throws Exception {
-        String objRef = mbean.getObjectName().toString();
-        String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
-        String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-        AdapterState report = new AdapterState().withId(id).withState(stateStr);
+    for (ObjectName channel : namedChannels) {
+      String objRef = channel.toString();
+      String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
+      String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+      boolean autoStart = BooleanUtils.toBoolean(getJmxMBeanHelper().getStringAttribute(objRef, AUTO_START));
+      ChannelState report = new ChannelState().withId(id).withState(stateStr);
+      if (autoStart) { // ignore channels and their children if not auto-start=true
         verifyReady(id, stateStr, handler);
-        Set<ObjectName> channels = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
-        addChannelStates(report, channels, handler);
         if (isCheckConnectionHealth()) {
-            Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
-            addConnectionStates(report, connections, handler, PARENT_TYPE_ADAPTER, id);
+          Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+          addConnectionStates(adapterState, connections, handler, PARENT_TYPE_CHANNEL, id);
         }
-        return report;
+        Set<ObjectName> workflows = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
+        addWorkflowStates(adapterState, report, workflows, handler);
+        adapterState.applyDefaultIfNull().add(report);
+      }
     }
+  }
 
-    private void addChannelStates(AdapterState adapterState, Set<ObjectName> namedChannels, IfNotReady handler) throws Exception {
-
-        for (ObjectName channel : namedChannels) {
-            String objRef = channel.toString();
-            String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
-            String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-            boolean autoStart = BooleanUtils.toBoolean(getJmxMBeanHelper().getStringAttribute(objRef, AUTO_START));
-            ChannelState report = new ChannelState().withId(id).withState(stateStr);
-            if (autoStart) { // ignore channels and their children if not auto-start=true
-                verifyReady(id, stateStr, handler);
-                if (isCheckConnectionHealth()) {
-                    Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
-                    addConnectionStates(adapterState, connections, handler, PARENT_TYPE_CHANNEL, id);
-                }
-                Set<ObjectName> workflows = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
-                addWorkflowStates(adapterState, report, workflows, handler);
-                adapterState.applyDefaultIfNull().add(report);
-            }
-        }
+  private void addWorkflowStates(AdapterState adapterState, ChannelState channelState, Set<ObjectName> namedWorkflows,
+      IfNotReady handler) throws Exception {
+    for (ObjectName workflow : namedWorkflows) {
+      // Channel children can include runtime info components (for example connection monitors).
+      // Only workflow ObjectNames should be processed in this block.
+      if (!WORKFLOW_TYPE.equals(workflow.getKeyProperty(TYPE_KEY))) {
+        continue;
+      }
+      String objRef = workflow.toString();
+      String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
+      String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+      WorkflowState report = new WorkflowState().withId(id).withState(stateStr);
+      verifyReady(id, stateStr, handler);
+      if (isCheckConnectionHealth()) {
+        Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+        addConnectionStates(adapterState, connections, handler, PARENT_TYPE_WORKFLOW, id);
+      }
+      channelState.applyDefaultIfNull().add(report);
     }
+  }
 
-    private void addWorkflowStates(AdapterState adapterState, ChannelState channelState, Set<ObjectName> namedWorkflows,
-                                   IfNotReady handler) throws Exception {
-        for (ObjectName workflow : namedWorkflows) {
-            // Channel children can include runtime info components (for example connection monitors).
-            // Only workflow ObjectNames should be processed in this block.
-            if (!WORKFLOW_TYPE.equals(workflow.getKeyProperty(TYPE_KEY))) {
-                continue;
-            }
-            String objRef = workflow.toString();
-            String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
-            String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-            WorkflowState report = new WorkflowState().withId(id).withState(stateStr);
-            verifyReady(id, stateStr, handler);
-            if (isCheckConnectionHealth()) {
-                Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
-                addConnectionStates(adapterState, connections, handler, PARENT_TYPE_WORKFLOW, id);
-            }
-            channelState.applyDefaultIfNull().add(report);
-        }
+  private void addConnectionStates(AdapterState adapterState, Set<ObjectName> connections, IfNotReady handler, String parentType,
+      String parentId) throws Exception {
+    for (ObjectName connectionName : connections) {
+      if (!CONNECTION_TYPE.equals(connectionName.getKeyProperty(TYPE_KEY))) {
+        continue;
+      }
+      String objRef = connectionName.toString();
+      String id = connectionName.getKeyProperty(ID_KEY);
+      String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+      ConnectionState report = new ConnectionState();
+      report.withId(id).withState(stateStr);
+      report.withParentType(parentType).withParentId(parentId);
+      verifyReady(id, stateStr, handler);
+      adapterState.applyConnectionDefaultIfNull().add(report);
     }
+  }
 
-    private void addConnectionStates(AdapterState adapterState, Set<ObjectName> connections, IfNotReady handler, String parentType,
-                                     String parentId) throws Exception {
-        for (ObjectName connectionName : connections) {
-            if (!CONNECTION_TYPE.equals(connectionName.getKeyProperty(TYPE_KEY))) {
-                continue;
-            }
-            String objRef = connectionName.toString();
-            String id = connectionName.getKeyProperty(ID_KEY);
-            String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-            ConnectionState report = new ConnectionState();
-            report.withId(id).withState(stateStr);
-            report.withParentType(parentType).withParentId(parentId);
-            verifyReady(id, stateStr, handler);
-            adapterState.applyConnectionDefaultIfNull().add(report);
-        }
+  private static void verifyReady(String id, String state, IfNotReady handler) throws Exception {
+    ComponentState compState = NAME_TO_COMPONENT_STATE.get(state);
+    // If we get our states out of sync (i.e. compState = null), then it's not ready.
+    if (!StartedState.getInstance().equals(compState)) {
+      handler.handle(id, compState);
     }
+  }
 
-    private static void verifyReady(String id, String state, IfNotReady handler) throws Exception {
-        ComponentState compState = NAME_TO_COMPONENT_STATE.get(state);
-        // If we get our states out of sync (i.e. compState = null), then it's not ready.
-        if (!StartedState.getInstance().equals(compState)) {
-            handler.handle(id, compState);
-        }
+  @Override
+  public void init(Properties config) throws Exception {
+    super.init(config);
+    setConfiguredUrlPath(config.getProperty(BOOTSTRAP_PATH_KEY));
+    setCheckConnectionHealth(BooleanUtils.toBoolean(config.getProperty(BOOTSTRAP_CONNECTION_CHECK_KEY)));
+  }
+
+  // What to do if the component isn't ready.
+  // Should a BiConsumer or some such.
+  @FunctionalInterface
+  private interface IfNotReady {
+    void handle(String id, ComponentState state) throws Exception;
+  }
+
+  // Basically this lambda is for handling the HTTP request that gets to us.
+  // Should just be a Consumer, but exceptions
+  @FunctionalInterface
+  private interface RequestHandler {
+    void handle(AdaptrisMessage msg) throws Exception;
+  }
+
+  private class NotReadyException extends Exception {
+    private static final long serialVersionUID = 2020060201L;
+
+    public NotReadyException(String e) {
+      super(e);
     }
-
-    @Override
-    public void init(Properties config) throws Exception {
-        super.init(config);
-        setConfiguredUrlPath(config.getProperty(BOOTSTRAP_PATH_KEY));
-        setCheckConnectionHealth(BooleanUtils.toBoolean(config.getProperty(BOOTSTRAP_CONNECTION_CHECK_KEY)));
-    }
-
-    // What to do if the component isn't ready.
-    // Should a BiConsumer or some such.
-    @FunctionalInterface
-    private interface IfNotReady {
-        void handle(String id, ComponentState state) throws Exception;
-    }
-
-    // Basically this lambda is for handling the HTTP request that gets to us.
-    // Should just be a Consumer, but exceptions
-    @FunctionalInterface
-    private interface RequestHandler {
-        void handle(AdaptrisMessage msg) throws Exception;
-    }
-
-    private class NotReadyException extends Exception {
-        private static final long serialVersionUID = 2020060201L;
-
-        public NotReadyException(String e) {
-            super(e);
-        }
-    }
+  }
 
 }

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
@@ -33,7 +33,6 @@ import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
 import com.adaptris.rest.AbstractRestfulEndpoint;
-
 import com.adaptris.rest.util.JmxMBeanHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
+++ b/interlok-rest-health-check/src/main/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponent.java
@@ -28,10 +28,12 @@ import com.adaptris.core.StoppedState;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.http.jetty.JettyConstants;
 import com.adaptris.rest.AbstractRestfulEndpoint;
+
 import static com.adaptris.rest.WorkflowServicesConsumer.CONTENT_TYPE_JSON;
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_DEFAULT;
 import static com.adaptris.rest.WorkflowServicesConsumer.ERROR_NOT_READY;
 import static com.adaptris.rest.WorkflowServicesConsumer.OK_200;
+
 import com.adaptris.rest.util.JmxMBeanHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -43,251 +45,251 @@ import lombok.SneakyThrows;
 @XStreamAlias("health-check")
 public class WorkflowHealthCheckComponent extends AbstractRestfulEndpoint {
 
-  private static final String BOOTSTRAP_PATH_KEY = "rest.health-check.path";
-  private static final String BOOTSTRAP_CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
+    private static final String BOOTSTRAP_PATH_KEY = "rest.health-check.path";
+    private static final String BOOTSTRAP_CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
 
-  private static final String ACCEPTED_FILTER = "GET";
+    private static final String ACCEPTED_FILTER = "GET";
 
-  private static final String DEFAULT_PATH = "/workflow-health-check/*";
+    private static final String DEFAULT_PATH = "/workflow-health-check/*";
 
-  private static final String ADAPTER_OBJ_TYPE_WILD = "com.adaptris:type=Adapter,*";
+    private static final String ADAPTER_OBJ_TYPE_WILD = "com.adaptris:type=Adapter,*";
 
-  private static final String UNIQUE_ID = "UniqueId";
-  private static final String ID_KEY = "id";
+    private static final String UNIQUE_ID = "UniqueId";
+    private static final String ID_KEY = "id";
 
-  private static final String CHILDREN_ATTRIBUTE = "Children";
-  private static final String CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE = "ChildRuntimeInfoComponents";
-  private static final String TYPE_KEY = "type";
-  private static final String CONNECTION_TYPE = "Connection";
-  private static final String WORKFLOW_TYPE = "Workflow";
-  private static final String PARENT_TYPE_ADAPTER = "adapter";
-  private static final String PARENT_TYPE_CHANNEL = "channel";
-  private static final String PARENT_TYPE_WORKFLOW = "workflow";
+    private static final String CHILDREN_ATTRIBUTE = "Children";
+    private static final String CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE = "ChildRuntimeInfoComponents";
+    private static final String TYPE_KEY = "type";
+    private static final String CONNECTION_TYPE = "Connection";
+    private static final String WORKFLOW_TYPE = "Workflow";
+    private static final String PARENT_TYPE_ADAPTER = "adapter";
+    private static final String PARENT_TYPE_CHANNEL = "channel";
+    private static final String PARENT_TYPE_WORKFLOW = "workflow";
 
-  private static final String COMPONENT_STATE = "ComponentState";
+    private static final String COMPONENT_STATE = "ComponentState";
 
-  private static final String AUTO_START = "AutoStart";
+    private static final String AUTO_START = "AutoStart";
 
-  private static final String PATH_KEY = JettyConstants.JETTY_URI;
+    private static final String PATH_KEY = JettyConstants.JETTY_URI;
 
-  private static final String LIVENESS_URL = "^.*/alive$";
-  private static final String READINESS_URL = "^.*/ready$";
-  private static final String DEFAULT_URL = "^.*$";
+    private static final String LIVENESS_URL = "^.*/alive$";
+    private static final String READINESS_URL = "^.*/ready$";
+    private static final String DEFAULT_URL = "^.*$";
 
-  private static final List<String> URL_PATTERNS = Collections.unmodifiableList(Arrays.asList(LIVENESS_URL, READINESS_URL, DEFAULT_URL));
+    private static final List<String> URL_PATTERNS = Collections.unmodifiableList(Arrays.asList(LIVENESS_URL, READINESS_URL, DEFAULT_URL));
 
-  // mapping "StartedState" -> StartedState.getInstance()
-  private static final List<ComponentState> STATE_LIST = Collections.unmodifiableList(
-      Arrays.asList(StoppedState.getInstance(), InitialisedState.getInstance(), StartedState.getInstance(), ClosedState.getInstance()));
+    // mapping "StartedState" -> StartedState.getInstance()
+    private static final List<ComponentState> STATE_LIST = Collections.unmodifiableList(
+            Arrays.asList(StoppedState.getInstance(), InitialisedState.getInstance(), StartedState.getInstance(), ClosedState.getInstance()));
 
-  private static final Map<String, ComponentState> NAME_TO_COMPONENT_STATE = Collections
-      .unmodifiableMap(STATE_LIST.stream().collect(Collectors.toMap((s) -> s.getClass().getSimpleName(), s -> s)));
+    private static final Map<String, ComponentState> NAME_TO_COMPONENT_STATE = Collections
+            .unmodifiableMap(STATE_LIST.stream().collect(Collectors.toMap((s) -> s.getClass().getSimpleName(), s -> s)));
 
-  @Getter(AccessLevel.PACKAGE)
-  @Setter(AccessLevel.PACKAGE)
-  private transient JmxMBeanHelper jmxMBeanHelper;
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
+    private transient JmxMBeanHelper jmxMBeanHelper;
 
-  @Setter(AccessLevel.PACKAGE)
-  private transient XStreamJsonMarshaller marshaller = null;
+    @Setter(AccessLevel.PACKAGE)
+    private transient XStreamJsonMarshaller marshaller = null;
 
-  @Getter(AccessLevel.PROTECTED)
-  private transient final String acceptedFilter = ACCEPTED_FILTER;
+    @Getter(AccessLevel.PROTECTED)
+    private transient final String acceptedFilter = ACCEPTED_FILTER;
 
-  @Getter(AccessLevel.PROTECTED)
-  private transient final String defaultUrlPath = DEFAULT_PATH;
+    @Getter(AccessLevel.PROTECTED)
+    private transient final String defaultUrlPath = DEFAULT_PATH;
 
-  @Getter(AccessLevel.PACKAGE)
-  @Setter(AccessLevel.PACKAGE)
-  private transient boolean checkConnectionHealth = false;
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
+    private transient boolean checkConnectionHealth = false;
 
-  // maps the jettyURI metadata value into its appropriate behaviour.
-  private final Map<String, RequestHandler> urlRoutes;
+    // maps the jettyURI metadata value into its appropriate behaviour.
+    private final Map<String, RequestHandler> urlRoutes;
 
-  public WorkflowHealthCheckComponent() {
-    super();
-    marshaller = new XStreamJsonMarshaller();
-    setJmxMBeanHelper(new JmxMBeanHelper());
-    urlRoutes = buildRoutes();
-  }
-
-  // Build the behaviour associated with each "branch" that is possible.
-  private Map<String, RequestHandler> buildRoutes() {
-    Map<String, RequestHandler> routes = new HashMap<>();
-    routes.put(LIVENESS_URL, (msg) -> {
-      // We are alive, because we got here, so just return a blank payload.
-      sendPayload(msg, Optional.empty());
-    });
-    routes.put(READINESS_URL, (msg) -> {
-      // ready means we need to check all the states, and if something isn't started we return a 503
-      buildAdapterStates((id, component) -> {
-        throw new NotReadyException(id + " is not started");
-      });
-      sendPayload(msg, Optional.empty());
-    });
-    routes.put(DEFAULT_URL, (msg) -> {
-      // otherwise we just get the list of states, and report on them.
-      List<AdapterState> states = buildAdapterStates((id, component) -> {
-      });
-      sendPayload(msg, Optional.of(states));
-    });
-    return routes;
-  }
-
-  @Override
-  public void onAdaptrisMessage(AdaptrisMessage message, Consumer<AdaptrisMessage> onSuccess, Consumer<AdaptrisMessage> onFailure) {
-    // this is arguably redundant because it's added in the consumer...
-    MDC.put(MDC_KEY, friendlyName());
-    String pathValue = message.getMetadataValue(PATH_KEY);
-    try {
-      // DEFAULT_BRANCH should always match, so if get() throws an exception
-      // then we're in an error state anyway.
-      RequestHandler handler = URL_PATTERNS.stream().filter((s) -> pathValue.matches(s)).findFirst().map((s) -> urlRoutes.get(s)).get();
-      handler.handle(message);
-      onSuccess.accept(message);
-    } catch (NotReadyException e) {
-      sendPayload(message, String.format("{\"failure\": \"%s\"}", e.getMessage()), ERROR_NOT_READY);
-    } catch (Exception e) {
-      doErrorResponse(message, e, ERROR_DEFAULT);
-      onFailure.accept(message);
-    } finally {
-      MDC.remove(MDC_KEY);
+    public WorkflowHealthCheckComponent() {
+        super();
+        marshaller = new XStreamJsonMarshaller();
+        setJmxMBeanHelper(new JmxMBeanHelper());
+        urlRoutes = buildRoutes();
     }
-  }
 
-  private void sendPayload(AdaptrisMessage message, String newPayload, int httpStatus) {
-    // Since JSON should always be UTF-8
-    message.setContent(newPayload, StandardCharsets.UTF_8.name());
-    doResponse(message, message, CONTENT_TYPE_JSON, httpStatus);
-  }
-
-  private void sendPayload(AdaptrisMessage message, Optional<List<AdapterState>> optState) {
-    String newPayload = optState.map((s) -> toString(s)).orElse("");
-    sendPayload(message, newPayload, OK_200);
-  }
-
-  @SneakyThrows
-  protected String toString(List<AdapterState> states) {
-    return marshaller.marshal(AdapterList.wrap(states));
-  }
-
-  private List<AdapterState> buildAdapterStates(IfNotReady handler) throws Exception {
-    List<AdapterState> states = new ArrayList<>();
-    Set<ObjectInstance> adapterMBeans = getJmxMBeanHelper().getMBeans(ADAPTER_OBJ_TYPE_WILD);
-    for (ObjectInstance adapterMBean : adapterMBeans) {
-      states.add(buildAdapterState(adapterMBean, handler));
+    // Build the behaviour associated with each "branch" that is possible.
+    private Map<String, RequestHandler> buildRoutes() {
+        Map<String, RequestHandler> routes = new HashMap<>();
+        routes.put(LIVENESS_URL, (msg) -> {
+            // We are alive, because we got here, so just return a blank payload.
+            sendPayload(msg, Optional.empty());
+        });
+        routes.put(READINESS_URL, (msg) -> {
+            // ready means we need to check all the states, and if something isn't started we return a 503
+            buildAdapterStates((id, component) -> {
+                throw new NotReadyException(id + " is not started");
+            });
+            sendPayload(msg, Optional.empty());
+        });
+        routes.put(DEFAULT_URL, (msg) -> {
+            // otherwise we just get the list of states, and report on them.
+            List<AdapterState> states = buildAdapterStates((id, component) -> {
+            });
+            sendPayload(msg, Optional.of(states));
+        });
+        return routes;
     }
-    return states;
-  }
 
-  private AdapterState buildAdapterState(ObjectInstance mbean, IfNotReady handler) throws Exception {
-    String objRef = mbean.getObjectName().toString();
-    String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
-    String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-    AdapterState report = new AdapterState().withId(id).withState(stateStr);
-    verifyReady(id, stateStr, handler);
-    Set<ObjectName> channels = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
-    addChannelStates(report, channels, handler);
-    if (isCheckConnectionHealth()) {
-      Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
-      addConnectionStates(report, connections, handler, PARENT_TYPE_ADAPTER, id);
-    }
-    return report;
-  }
-
-  private void addChannelStates(AdapterState adapterState, Set<ObjectName> namedChannels, IfNotReady handler) throws Exception {
-
-    for (ObjectName channel : namedChannels) {
-      String objRef = channel.toString();
-      String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
-      String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-      boolean autoStart = BooleanUtils.toBoolean(getJmxMBeanHelper().getStringAttribute(objRef, AUTO_START));
-      ChannelState report = new ChannelState().withId(id).withState(stateStr);
-      if(autoStart) { // ignore channels and their children if not auto-start=true
-        verifyReady(id, stateStr, handler);
-        if (isCheckConnectionHealth()) {
-          Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
-          addConnectionStates(adapterState, connections, handler, PARENT_TYPE_CHANNEL, id);
+    @Override
+    public void onAdaptrisMessage(AdaptrisMessage message, Consumer<AdaptrisMessage> onSuccess, Consumer<AdaptrisMessage> onFailure) {
+        // this is arguably redundant because it's added in the consumer...
+        MDC.put(MDC_KEY, friendlyName());
+        String pathValue = message.getMetadataValue(PATH_KEY);
+        try {
+            // DEFAULT_BRANCH should always match, so if get() throws an exception
+            // then we're in an error state anyway.
+            RequestHandler handler = URL_PATTERNS.stream().filter((s) -> pathValue.matches(s)).findFirst().map((s) -> urlRoutes.get(s)).get();
+            handler.handle(message);
+            onSuccess.accept(message);
+        } catch (NotReadyException e) {
+            sendPayload(message, String.format("{\"failure\": \"%s\"}", e.getMessage()), ERROR_NOT_READY);
+        } catch (Exception e) {
+            doErrorResponse(message, e, ERROR_DEFAULT);
+            onFailure.accept(message);
+        } finally {
+            MDC.remove(MDC_KEY);
         }
-        Set<ObjectName> workflows = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
-        addWorkflowStates(adapterState, report, workflows, handler);
-        adapterState.applyDefaultIfNull().add(report);
-      }
     }
-  }
 
-  private void addWorkflowStates(AdapterState adapterState, ChannelState channelState, Set<ObjectName> namedWorkflows,
-      IfNotReady handler) throws Exception {
-    for (ObjectName workflow : namedWorkflows) {
-      // Channel children can include runtime info components (for example connection monitors).
-      // Only workflow ObjectNames should be processed in this block.
-      if (!WORKFLOW_TYPE.equals(workflow.getKeyProperty(TYPE_KEY))) {
-        continue;
-      }
-      String objRef = workflow.toString();
-      String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
-      String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-      WorkflowState report = new WorkflowState().withId(id).withState(stateStr);
-      verifyReady(id, stateStr, handler);
-      if (isCheckConnectionHealth()) {
-        Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
-        addConnectionStates(adapterState, connections, handler, PARENT_TYPE_WORKFLOW, id);
-      }
-      channelState.applyDefaultIfNull().add(report);
+    private void sendPayload(AdaptrisMessage message, String newPayload, int httpStatus) {
+        // Since JSON should always be UTF-8
+        message.setContent(newPayload, StandardCharsets.UTF_8.name());
+        doResponse(message, message, CONTENT_TYPE_JSON, httpStatus);
     }
-  }
 
-  private void addConnectionStates(AdapterState adapterState, Set<ObjectName> connections, IfNotReady handler, String parentType,
-      String parentId) throws Exception {
-    for (ObjectName connectionName : connections) {
-      if (!CONNECTION_TYPE.equals(connectionName.getKeyProperty(TYPE_KEY))) {
-        continue;
-      }
-      String objRef = connectionName.toString();
-      String id = connectionName.getKeyProperty(ID_KEY);
-      String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
-      ConnectionState report = new ConnectionState();
-      report.withId(id).withState(stateStr);
-      report.withParentType(parentType).withParentId(parentId);
-      verifyReady(id, stateStr, handler);
-      adapterState.applyConnectionDefaultIfNull().add(report);
+    private void sendPayload(AdaptrisMessage message, Optional<List<AdapterState>> optState) {
+        String newPayload = optState.map((s) -> toString(s)).orElse("");
+        sendPayload(message, newPayload, OK_200);
     }
-  }
 
-  private static void verifyReady(String id, String state, IfNotReady handler) throws Exception {
-    ComponentState compState = NAME_TO_COMPONENT_STATE.get(state);
-    // If we get our states out of sync (i.e. compState = null), then it's not ready.
-    if (!StartedState.getInstance().equals(compState)) {
-      handler.handle(id, compState);
+    @SneakyThrows
+    protected String toString(List<AdapterState> states) {
+        return marshaller.marshal(AdapterList.wrap(states));
     }
-  }
 
-  @Override
-  public void init(Properties config) throws Exception {
-    super.init(config);
-    setConfiguredUrlPath(config.getProperty(BOOTSTRAP_PATH_KEY));
-    setCheckConnectionHealth(BooleanUtils.toBoolean(config.getProperty(BOOTSTRAP_CONNECTION_CHECK_KEY)));
-  }
-
-  // What to do if the component isn't ready.
-  // Should a BiConsumer or some such.
-  @FunctionalInterface
-  private interface IfNotReady {
-    void handle(String id, ComponentState state) throws Exception;
-  }
-
-  // Basically this lambda is for handling the HTTP request that gets to us.
-  // Should just be a Consumer, but exceptions
-  @FunctionalInterface
-  private interface RequestHandler {
-    void handle(AdaptrisMessage msg) throws Exception;
-  }
-
-  private class NotReadyException extends Exception {
-    private static final long serialVersionUID = 2020060201L;
-
-    public NotReadyException(String e) {
-      super(e);
+    private List<AdapterState> buildAdapterStates(IfNotReady handler) throws Exception {
+        List<AdapterState> states = new ArrayList<>();
+        Set<ObjectInstance> adapterMBeans = getJmxMBeanHelper().getMBeans(ADAPTER_OBJ_TYPE_WILD);
+        for (ObjectInstance adapterMBean : adapterMBeans) {
+            states.add(buildAdapterState(adapterMBean, handler));
+        }
+        return states;
     }
-  }
+
+    private AdapterState buildAdapterState(ObjectInstance mbean, IfNotReady handler) throws Exception {
+        String objRef = mbean.getObjectName().toString();
+        String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
+        String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+        AdapterState report = new AdapterState().withId(id).withState(stateStr);
+        verifyReady(id, stateStr, handler);
+        Set<ObjectName> channels = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
+        addChannelStates(report, channels, handler);
+        if (isCheckConnectionHealth()) {
+            Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+            addConnectionStates(report, connections, handler, PARENT_TYPE_ADAPTER, id);
+        }
+        return report;
+    }
+
+    private void addChannelStates(AdapterState adapterState, Set<ObjectName> namedChannels, IfNotReady handler) throws Exception {
+
+        for (ObjectName channel : namedChannels) {
+            String objRef = channel.toString();
+            String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
+            String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+            boolean autoStart = BooleanUtils.toBoolean(getJmxMBeanHelper().getStringAttribute(objRef, AUTO_START));
+            ChannelState report = new ChannelState().withId(id).withState(stateStr);
+            if (autoStart) { // ignore channels and their children if not auto-start=true
+                verifyReady(id, stateStr, handler);
+                if (isCheckConnectionHealth()) {
+                    Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+                    addConnectionStates(adapterState, connections, handler, PARENT_TYPE_CHANNEL, id);
+                }
+                Set<ObjectName> workflows = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILDREN_ATTRIBUTE);
+                addWorkflowStates(adapterState, report, workflows, handler);
+                adapterState.applyDefaultIfNull().add(report);
+            }
+        }
+    }
+
+    private void addWorkflowStates(AdapterState adapterState, ChannelState channelState, Set<ObjectName> namedWorkflows,
+                                   IfNotReady handler) throws Exception {
+        for (ObjectName workflow : namedWorkflows) {
+            // Channel children can include runtime info components (for example connection monitors).
+            // Only workflow ObjectNames should be processed in this block.
+            if (!WORKFLOW_TYPE.equals(workflow.getKeyProperty(TYPE_KEY))) {
+                continue;
+            }
+            String objRef = workflow.toString();
+            String id = getJmxMBeanHelper().getStringAttribute(objRef, UNIQUE_ID);
+            String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+            WorkflowState report = new WorkflowState().withId(id).withState(stateStr);
+            verifyReady(id, stateStr, handler);
+            if (isCheckConnectionHealth()) {
+                Set<ObjectName> connections = getJmxMBeanHelper().getObjectSetAttribute(objRef, CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE);
+                addConnectionStates(adapterState, connections, handler, PARENT_TYPE_WORKFLOW, id);
+            }
+            channelState.applyDefaultIfNull().add(report);
+        }
+    }
+
+    private void addConnectionStates(AdapterState adapterState, Set<ObjectName> connections, IfNotReady handler, String parentType,
+                                     String parentId) throws Exception {
+        for (ObjectName connectionName : connections) {
+            if (!CONNECTION_TYPE.equals(connectionName.getKeyProperty(TYPE_KEY))) {
+                continue;
+            }
+            String objRef = connectionName.toString();
+            String id = connectionName.getKeyProperty(ID_KEY);
+            String stateStr = getJmxMBeanHelper().getStringAttributeClassName(objRef, COMPONENT_STATE);
+            ConnectionState report = new ConnectionState();
+            report.withId(id).withState(stateStr);
+            report.withParentType(parentType).withParentId(parentId);
+            verifyReady(id, stateStr, handler);
+            adapterState.applyConnectionDefaultIfNull().add(report);
+        }
+    }
+
+    private static void verifyReady(String id, String state, IfNotReady handler) throws Exception {
+        ComponentState compState = NAME_TO_COMPONENT_STATE.get(state);
+        // If we get our states out of sync (i.e. compState = null), then it's not ready.
+        if (!StartedState.getInstance().equals(compState)) {
+            handler.handle(id, compState);
+        }
+    }
+
+    @Override
+    public void init(Properties config) throws Exception {
+        super.init(config);
+        setConfiguredUrlPath(config.getProperty(BOOTSTRAP_PATH_KEY));
+        setCheckConnectionHealth(BooleanUtils.toBoolean(config.getProperty(BOOTSTRAP_CONNECTION_CHECK_KEY)));
+    }
+
+    // What to do if the component isn't ready.
+    // Should a BiConsumer or some such.
+    @FunctionalInterface
+    private interface IfNotReady {
+        void handle(String id, ComponentState state) throws Exception;
+    }
+
+    // Basically this lambda is for handling the HTTP request that gets to us.
+    // Should just be a Consumer, but exceptions
+    @FunctionalInterface
+    private interface RequestHandler {
+        void handle(AdaptrisMessage msg) throws Exception;
+    }
+
+    private class NotReadyException extends Exception {
+        private static final long serialVersionUID = 2020060201L;
+
+        public NotReadyException(String e) {
+            super(e);
+        }
+    }
 
 }

--- a/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
+++ b/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
@@ -58,12 +58,14 @@ public class WorkflowHealthCheckComponentTest {
   
   private static final String CHANNEL_OBJECT_NAME = "com.adaptris:type=Channel,adapter=" + ADAPTER_ID + ",id=" + CHANNEL_ID;
   private static final String WORKFLOW_OBJECT_NAME_1 = "com.adaptris:type=Workflow,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + WORKFLOW_ID1;
-  private static final String WORKFLOW_OBJECT_NAME_2 = "com.adaptris:type=Channel,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + WORKFLOW_ID2;
+  private static final String WORKFLOW_OBJECT_NAME_2 = "com.adaptris:type=Workflow,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + WORKFLOW_ID2;
   private static final String CONNECTION_OBJECT_NAME_ADAPTER = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",id=" + CONNECTION_ID_ADAPTER;
   private static final String CONNECTION_OBJECT_NAME_CHANNEL = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + CONNECTION_ID_CHANNEL;
   private static final String CONNECTION_OBJECT_NAME_WORKFLOW = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",workflow=" + WORKFLOW_ID1 + ",id=" + CONNECTION_ID_WORKFLOW;
   private static final String NON_CONNECTION_ID = "NotAConnection";
   private static final String NON_CONNECTION_OBJECT_NAME_ADAPTER = "com.adaptris:type=Service,adapter=" + ADAPTER_ID + ",id=" + NON_CONNECTION_ID;
+  private static final String NON_WORKFLOW_CHILD_ID = "NotAWorkflow";
+  private static final String NON_WORKFLOW_CHILD_OBJECT_NAME = "com.adaptris:type=Channel,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + NON_WORKFLOW_CHILD_ID;
   private static final String PATH_KEY = JettyConstants.JETTY_URI;
   private static final String CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
 
@@ -162,7 +164,7 @@ public class WorkflowHealthCheckComponentTest {
       assertTrue(testConsumer.payload.contains(ADAPTER_ID));
       assertTrue(testConsumer.payload.contains(CHANNEL_ID));
       assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
-      assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
+      assertTrue(testConsumer.payload.contains(WORKFLOW_ID2));
     } finally {
       wrapper.destroy();
     }
@@ -208,7 +210,7 @@ public class WorkflowHealthCheckComponentTest {
       assertTrue(testConsumer.payload.contains(ADAPTER_ID));
       assertTrue(testConsumer.payload.contains(CHANNEL_ID));
       assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
-      assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
+      assertTrue(testConsumer.payload.contains(WORKFLOW_ID2));
     } finally {
       wrapper.destroy();
     }
@@ -278,7 +280,7 @@ public class WorkflowHealthCheckComponentTest {
     TestConsumer testConsumer = wrapper.testConsumer();
     JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
     try {
-      when(mockJmxHelper.getStringAttributeClassName(CONNECTION_OBJECT_NAME_ADAPTER, COMPONENT_STATE))
+      when(mockJmxHelper.getStringAttributeClassName(new ObjectName(CONNECTION_OBJECT_NAME_ADAPTER).toString(), COMPONENT_STATE))
           .thenReturn(StoppedState.class.getSimpleName());
 
       Properties p = new Properties();
@@ -330,9 +332,9 @@ public class WorkflowHealthCheckComponentTest {
 
     Set<ObjectName> mixedChildren = new HashSet<>();
     ObjectName workflowObjectName1 = new ObjectName(WORKFLOW_OBJECT_NAME_1);
-    ObjectName workflowConnection = new ObjectName(CONNECTION_OBJECT_NAME_WORKFLOW);
+    ObjectName nonWorkflowChild = new ObjectName(NON_WORKFLOW_CHILD_OBJECT_NAME);
     mixedChildren.add(workflowObjectName1);
-    mixedChildren.add(workflowConnection);
+    mixedChildren.add(nonWorkflowChild);
 
     when(mockJmxHelper.getObjectSetAttribute(new ObjectName(CHANNEL_OBJECT_NAME).toString(), CHILDREN_ATTRIBUTE))
         .thenReturn(mixedChildren);
@@ -347,7 +349,7 @@ public class WorkflowHealthCheckComponentTest {
       assertFalse(testConsumer.isError);
       assertEquals(HttpURLConnection.HTTP_OK, testConsumer.httpStatus);
       assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
-      assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
+      assertFalse(testConsumer.payload.contains(NON_WORKFLOW_CHILD_ID));
     } finally {
       wrapper.destroy();
     }

--- a/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
+++ b/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
@@ -273,7 +273,7 @@ public class WorkflowHealthCheckComponentTest {
   }
 
   @Test
-  public void testReadiness_NotReadyWhenConnectionStopped() throws Exception {
+  void testReadiness_NotReadyWhenConnectionStopped() throws Exception {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
@@ -297,7 +297,7 @@ public class WorkflowHealthCheckComponentTest {
   }
 
   @Test
-  public void testHealthCheck_ConnectionParentsIncluded() throws Exception {
+  void testHealthCheck_ConnectionParentsIncluded() throws Exception {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
@@ -323,7 +323,7 @@ public class WorkflowHealthCheckComponentTest {
   }
 
   @Test
-  public void testHealthCheck_IgnoresNonWorkflowChildren() throws Exception {
+  void testHealthCheck_IgnoresNonWorkflowChildren() throws Exception {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
@@ -356,7 +356,7 @@ public class WorkflowHealthCheckComponentTest {
   }
 
   @Test
-  public void testHealthCheck_IgnoresNonConnectionRuntimeComponents() throws Exception {
+  void testHealthCheck_IgnoresNonConnectionRuntimeComponents() throws Exception {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     message.addMessageHeader(PATH_KEY, "/workflow-health-check");
     MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);

--- a/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
+++ b/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
@@ -49,13 +49,21 @@ public class WorkflowHealthCheckComponentTest {
   private static final String WORKFLOW_ID2 = "MyWorkflowId2";
   private static final String UNIQUE_ID = "UniqueId";
   private static final String CHILDREN_ATTRIBUTE = "Children";
+  private static final String CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE = "ChildRuntimeInfoComponents";
   private static final String COMPONENT_STATE = "ComponentState";
   private static final String AUTO_START = "AutoStart";
+  private static final String CONNECTION_ID_ADAPTER = "AdapterConnection";
+  private static final String CONNECTION_ID_CHANNEL = "ChannelConnection";
+  private static final String CONNECTION_ID_WORKFLOW = "WorkflowConnection";
   
   private static final String CHANNEL_OBJECT_NAME = "com.adaptris:type=Channel,adapter=" + ADAPTER_ID + ",id=" + CHANNEL_ID;
   private static final String WORKFLOW_OBJECT_NAME_1 = "com.adaptris:type=Workflow,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + WORKFLOW_ID1;
   private static final String WORKFLOW_OBJECT_NAME_2 = "com.adaptris:type=Channel,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + WORKFLOW_ID2;
+  private static final String CONNECTION_OBJECT_NAME_ADAPTER = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",id=" + CONNECTION_ID_ADAPTER;
+  private static final String CONNECTION_OBJECT_NAME_CHANNEL = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + CONNECTION_ID_CHANNEL;
+  private static final String CONNECTION_OBJECT_NAME_WORKFLOW = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",workflow=" + WORKFLOW_ID1 + ",id=" + CONNECTION_ID_WORKFLOW;
   private static final String PATH_KEY = JettyConstants.JETTY_URI;
+  private static final String CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
 
   @Test
   public void testMarshalling() throws Exception {
@@ -152,7 +160,7 @@ public class WorkflowHealthCheckComponentTest {
       assertTrue(testConsumer.payload.contains(ADAPTER_ID));
       assertTrue(testConsumer.payload.contains(CHANNEL_ID));
       assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
-      assertTrue(testConsumer.payload.contains(WORKFLOW_ID2));
+      assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
     } finally {
       wrapper.destroy();
     }
@@ -198,7 +206,7 @@ public class WorkflowHealthCheckComponentTest {
       assertTrue(testConsumer.payload.contains(ADAPTER_ID));
       assertTrue(testConsumer.payload.contains(CHANNEL_ID));
       assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
-      assertTrue(testConsumer.payload.contains(WORKFLOW_ID2));
+      assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
     } finally {
       wrapper.destroy();
     }
@@ -260,6 +268,89 @@ public class WorkflowHealthCheckComponentTest {
     }
   }
 
+  @Test
+  public void testReadiness_NotReadyWhenConnectionStopped() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check/ready");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    TestConsumer testConsumer = wrapper.testConsumer();
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    try {
+      when(mockJmxHelper.getStringAttributeClassName(CONNECTION_OBJECT_NAME_ADAPTER, COMPONENT_STATE))
+          .thenReturn(StoppedState.class.getSimpleName());
+
+      Properties p = new Properties();
+      p.setProperty(CONNECTION_CHECK_KEY, "true");
+      wrapper.start(p);
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS).until(testConsumer::complete);
+      assertEquals(HttpURLConnection.HTTP_UNAVAILABLE, testConsumer.httpStatus);
+      assertTrue(testConsumer.payload.contains("is not started"));
+    } finally {
+      wrapper.destroy();
+    }
+  }
+
+  @Test
+  public void testHealthCheck_ConnectionParentsIncluded() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    TestConsumer testConsumer = wrapper.testConsumer();
+    try {
+      Properties p = new Properties();
+      p.setProperty(CONNECTION_CHECK_KEY, "true");
+      wrapper.start(p);
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS).until(testConsumer::complete);
+      assertFalse(testConsumer.isError);
+      assertTrue(testConsumer.payload.contains("\"connection-states\""));
+      assertTrue(testConsumer.payload.contains("\"parent-type\":\"adapter\""));
+      assertTrue(testConsumer.payload.contains("\"parent-id\":\"" + ADAPTER_ID + "\""));
+      assertTrue(testConsumer.payload.contains("\"parent-type\":\"channel\""));
+      assertTrue(testConsumer.payload.contains("\"parent-id\":\"" + CHANNEL_ID + "\""));
+      assertTrue(testConsumer.payload.contains("\"parent-type\":\"workflow\""));
+      assertTrue(testConsumer.payload.contains("\"parent-id\":\"" + WORKFLOW_ID1 + "\""));
+    } finally {
+      wrapper.destroy();
+    }
+  }
+
+  @Test
+  public void testHealthCheck_IgnoresNonWorkflowChildren() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+
+    Set<ObjectName> mixedChildren = new HashSet<>();
+    ObjectName workflowObjectName1 = new ObjectName(WORKFLOW_OBJECT_NAME_1);
+    ObjectName workflowConnection = new ObjectName(CONNECTION_OBJECT_NAME_WORKFLOW);
+    mixedChildren.add(workflowObjectName1);
+    mixedChildren.add(workflowConnection);
+
+    when(mockJmxHelper.getObjectSetAttribute(new ObjectName(CHANNEL_OBJECT_NAME).toString(), CHILDREN_ATTRIBUTE))
+        .thenReturn(mixedChildren);
+
+    try {
+      Properties p = new Properties();
+      p.setProperty(CONNECTION_CHECK_KEY, "true");
+      wrapper.start(p);
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS).until(testConsumer::complete);
+      assertFalse(testConsumer.isError);
+      assertEquals(HttpURLConnection.HTTP_OK, testConsumer.httpStatus);
+      assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
+      assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
+    } finally {
+      wrapper.destroy();
+    }
+  }
+
   // Can't do this in @BeforeEach / @AfterEach since I want to control the mocking behaviour.
   private class MockedHealthCheckWrapper {
 
@@ -289,16 +380,32 @@ public class WorkflowHealthCheckComponentTest {
       workflowObjectNames.add(workflowObjectName1);
       workflowObjectNames.add(workflowObjectName2);
 
+      Set<ObjectName> adapterConnectionObjectNames = new HashSet<>();
+      ObjectName adapterConnection = new ObjectName(CONNECTION_OBJECT_NAME_ADAPTER);
+      adapterConnectionObjectNames.add(adapterConnection);
+
+      Set<ObjectName> channelConnectionObjectNames = new HashSet<>();
+      ObjectName channelConnection = new ObjectName(CONNECTION_OBJECT_NAME_CHANNEL);
+      channelConnectionObjectNames.add(channelConnection);
+
+      Set<ObjectName> workflowConnectionObjectNames = new HashSet<>();
+      ObjectName workflowConnection = new ObjectName(CONNECTION_OBJECT_NAME_WORKFLOW);
+      workflowConnectionObjectNames.add(workflowConnection);
+
       when(mockJmxHelper.getMBeans(anyString())).thenReturn(adapterInstances);
       when(mockJmxHelper.getStringAttribute(adapterObjectName.toString(), UNIQUE_ID)).thenReturn(ADAPTER_ID);
       when(mockJmxHelper.getStringAttributeClassName(adapterObjectName.toString(), COMPONENT_STATE))
           .thenReturn(StartedState.class.getSimpleName());
 
       when(mockJmxHelper.getObjectSetAttribute(adapterObjectName.toString(), CHILDREN_ATTRIBUTE)).thenReturn(channelObjectNames);
+        when(mockJmxHelper.getObjectSetAttribute(adapterObjectName.toString(), CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE))
+          .thenReturn(adapterConnectionObjectNames);
       when(mockJmxHelper.getStringAttribute(channelObjectName.toString(), UNIQUE_ID)).thenReturn(CHANNEL_ID);
       when(mockJmxHelper.getStringAttribute(channelObjectName.toString(), AUTO_START)).thenReturn("true");
       when(mockJmxHelper.getStringAttributeClassName(channelObjectName.toString(), COMPONENT_STATE))
           .thenReturn(StartedState.class.getSimpleName());
+        when(mockJmxHelper.getObjectSetAttribute(channelObjectName.toString(), CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE))
+          .thenReturn(channelConnectionObjectNames);
 
       when(mockJmxHelper.getObjectSetAttribute(channelObjectName.toString(), CHILDREN_ATTRIBUTE)).thenReturn(workflowObjectNames);
 
@@ -309,9 +416,25 @@ public class WorkflowHealthCheckComponentTest {
 
       when(mockJmxHelper.getStringAttribute(workflowObjectName1.toString(), UNIQUE_ID)).thenReturn(WORKFLOW_ID1);
       when(mockJmxHelper.getStringAttributeClassName(workflowObjectName1.toString(), COMPONENT_STATE)).thenReturn(workflowState);
+        when(mockJmxHelper.getObjectSetAttribute(workflowObjectName1.toString(), CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE))
+          .thenReturn(workflowConnectionObjectNames);
 
       when(mockJmxHelper.getStringAttribute(workflowObjectName2.toString(), UNIQUE_ID)).thenReturn(WORKFLOW_ID2);
       when(mockJmxHelper.getStringAttributeClassName(workflowObjectName2.toString(), COMPONENT_STATE)).thenReturn(workflowState);
+        when(mockJmxHelper.getObjectSetAttribute(workflowObjectName2.toString(), CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE))
+          .thenReturn(Collections.emptySet());
+
+        when(mockJmxHelper.getStringAttribute(adapterConnection.toString(), UNIQUE_ID)).thenReturn(CONNECTION_ID_ADAPTER);
+        when(mockJmxHelper.getStringAttributeClassName(adapterConnection.toString(), COMPONENT_STATE))
+          .thenReturn(StartedState.class.getSimpleName());
+
+        when(mockJmxHelper.getStringAttribute(channelConnection.toString(), UNIQUE_ID)).thenReturn(CONNECTION_ID_CHANNEL);
+        when(mockJmxHelper.getStringAttributeClassName(channelConnection.toString(), COMPONENT_STATE))
+          .thenReturn(StartedState.class.getSimpleName());
+
+        when(mockJmxHelper.getStringAttribute(workflowConnection.toString(), UNIQUE_ID)).thenReturn(CONNECTION_ID_WORKFLOW);
+        when(mockJmxHelper.getStringAttributeClassName(workflowConnection.toString(), COMPONENT_STATE))
+          .thenReturn(StartedState.class.getSimpleName());
 
       healthCheck = new WorkflowHealthCheckComponent();
       testConsumer = new TestConsumer();
@@ -321,7 +444,11 @@ public class WorkflowHealthCheckComponentTest {
     }
 
     public void start() throws Exception {
-      healthCheck.init(new Properties());
+      start(new Properties());
+    }
+
+    public void start(Properties properties) throws Exception {
+      healthCheck.init(properties);
       healthCheck.start();
 
     }

--- a/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
+++ b/interlok-rest-health-check/src/test/java/com/adaptris/rest/healthcheck/WorkflowHealthCheckComponentTest.java
@@ -62,6 +62,8 @@ public class WorkflowHealthCheckComponentTest {
   private static final String CONNECTION_OBJECT_NAME_ADAPTER = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",id=" + CONNECTION_ID_ADAPTER;
   private static final String CONNECTION_OBJECT_NAME_CHANNEL = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",id=" + CONNECTION_ID_CHANNEL;
   private static final String CONNECTION_OBJECT_NAME_WORKFLOW = "com.adaptris:type=Connection,adapter=" + ADAPTER_ID + ",channel=" + CHANNEL_ID + ",workflow=" + WORKFLOW_ID1 + ",id=" + CONNECTION_ID_WORKFLOW;
+  private static final String NON_CONNECTION_ID = "NotAConnection";
+  private static final String NON_CONNECTION_OBJECT_NAME_ADAPTER = "com.adaptris:type=Service,adapter=" + ADAPTER_ID + ",id=" + NON_CONNECTION_ID;
   private static final String PATH_KEY = JettyConstants.JETTY_URI;
   private static final String CONNECTION_CHECK_KEY = "rest.health-check.connection-check";
 
@@ -346,6 +348,37 @@ public class WorkflowHealthCheckComponentTest {
       assertEquals(HttpURLConnection.HTTP_OK, testConsumer.httpStatus);
       assertTrue(testConsumer.payload.contains(WORKFLOW_ID1));
       assertFalse(testConsumer.payload.contains(WORKFLOW_ID2));
+    } finally {
+      wrapper.destroy();
+    }
+  }
+
+  @Test
+  public void testHealthCheck_IgnoresNonConnectionRuntimeComponents() throws Exception {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMessageHeader(PATH_KEY, "/workflow-health-check");
+    MockedHealthCheckWrapper wrapper = new MockedHealthCheckWrapper().build(true);
+    JmxMBeanHelper mockJmxHelper = wrapper.jmxHelper();
+    TestConsumer testConsumer = wrapper.testConsumer();
+
+    Set<ObjectName> mixedRuntimeComponents = new HashSet<>();
+    mixedRuntimeComponents.add(new ObjectName(CONNECTION_OBJECT_NAME_ADAPTER));
+    mixedRuntimeComponents.add(new ObjectName(NON_CONNECTION_OBJECT_NAME_ADAPTER));
+
+    when(mockJmxHelper.getObjectSetAttribute(new ObjectName("com.adaptris:type=Adapter,id=" + ADAPTER_ID).toString(),
+        CHILD_RUNTIME_INFO_COMPONENTS_ATTRIBUTE)).thenReturn(mixedRuntimeComponents);
+
+    try {
+      Properties p = new Properties();
+      p.setProperty(CONNECTION_CHECK_KEY, "true");
+      wrapper.start(p);
+      wrapper.healthCheck().onAdaptrisMessage(message);
+
+      await().atMost(Durations.FIVE_SECONDS).with().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS).until(testConsumer::complete);
+      assertFalse(testConsumer.isError);
+      assertEquals(HttpURLConnection.HTTP_OK, testConsumer.httpStatus);
+      assertTrue(testConsumer.payload.contains(CONNECTION_ID_ADAPTER));
+      assertFalse(testConsumer.payload.contains(NON_CONNECTION_ID));
     } finally {
       wrapper.destroy();
     }


### PR DESCRIPTION
## Motivation

- Extending health checks so connection health is included when you opt-in, not just adapter/channel/workflow states.
- In readiness mode, this lets /ready fail  with 503 when required connections are unhealthy
- This is controlled by new config rest.health-check.connection-check so existing behavior remains default unless enabled.
- This depends on changes here: https://github.com/adaptris/interlok/pull/206 and https://github.com/adaptris/interlok-solace/pull/529 

## Modification

- Added new model for connection health entries which looks at new ConnectionMonitor runtime info components
- Added opt-in bootstrap key rest.health-check.connection-check.
- Added logic to collect connection runtime info from
  - adapter-level runtime components,
  - channel-level runtime components,
  - workflow-level runtime components
- Added filtering so only workflow children are treated as workflows.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

Connection State will be available health check endpoint when we opt in, readiness will not return 200 if connections are not in a healthy state

## Testing

### Interlok Config

<details>

```xml
<adapter>
  <unique-id>test-adapter</unique-id>
  <start-up-event-imp>com.adaptris.core.event.StandardAdapterStartUpEvent</start-up-event-imp>
  <heartbeat-event-imp>com.adaptris.core.HeartbeatEvent</heartbeat-event-imp>
  <shared-components>
    <connections>
      <jetty-embedded-connection>
        <unique-id>embedded-jetty-connection</unique-id>
      </jetty-embedded-connection>
      <jms-connection>
        <connection-state-handler class="solace-connection-state-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
      <jms-connection>
        <connection-state-handler class="solace-connection-state-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection-2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
      <jms-connection>
        <connection-state-handler class="solace-connection-state-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection 2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
      <jms-connection>
        <connection-state-handler class="solace-connection-state-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection 3</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
    </connections>
    <services>
      <standalone-producer>
        <unique-id>solace-jms 3</unique-id>
        <connection class="jms-connection">
          <connection-state-handler class="solace-connection-state-handler"/>
          <runtime-component>true</runtime-component>
          <unique-id>solace-jms-connection-3</unique-id>
          <connection-attempts>-1</connection-attempts>
          <user-name>default</user-name>
          <password>admin</password>
          <client-id>local_client</client-id>
          <vendor-implementation class="advanced-solace-implementation">
            <broker-url>tcp://localhost:55555</broker-url>
            <message-vpn>default</message-vpn>
            <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
            <delivery-mode>PERSISTENT</delivery-mode>
            <solace-keepalive>
              <keep-alives>true</keep-alives>
              <keep-alive-count-max>5</keep-alive-count-max>
              <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
            </solace-keepalive>
            <solace-connection-tuning>
              <connect-retries>-1</connect-retries>
              <reconnect-retries>-1</reconnect-retries>
            </solace-connection-tuning>
            <properties/>
          </vendor-implementation>
        </connection>
        <producer class="null-message-producer">
          <unique-id>affectionate-shirley</unique-id>
        </producer>
      </standalone-producer>
      <standalone-producer>
        <unique-id>solace-jms 4</unique-id>
        <connection class="jms-connection">
          <connection-state-handler class="solace-connection-state-handler"/>
          <runtime-component>true</runtime-component>
          <unique-id>solace-jms-connection-3</unique-id>
          <connection-attempts>-1</connection-attempts>
          <user-name>default</user-name>
          <password>admin</password>
          <client-id>local_client</client-id>
          <vendor-implementation class="advanced-solace-implementation">
            <broker-url>tcp://localhost:55555</broker-url>
            <message-vpn>default</message-vpn>
            <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
            <delivery-mode>PERSISTENT</delivery-mode>
            <solace-keepalive>
              <keep-alives>true</keep-alives>
              <keep-alive-count-max>5</keep-alive-count-max>
              <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
            </solace-keepalive>
            <solace-connection-tuning>
              <connect-retries>-1</connect-retries>
              <reconnect-retries>-1</reconnect-retries>
            </solace-connection-tuning>
            <properties/>
          </vendor-implementation>
        </connection>
        <producer class="null-message-producer">
          <unique-id>affectionate-shirley</unique-id>
        </producer>
      </standalone-producer>
    </services>
  </shared-components>
  <event-handler class="configurable-event-handler">
    <unique-id>ConfigurableEventHandler</unique-id>
    <connection class="null-connection">
      <unique-id>default-null-connection</unique-id>
    </connection>
    <producer class="null-message-producer">
      <unique-id>default-null-message-producer</unique-id>
    </producer>
    <rule>
      <matcher class="regex-event-matcher">
        <regex>com\.adaptris\.core\.MessageLifecycleEvent</regex>
        <match-type>TYPE</match-type>
      </matcher>
      <standalone-producer>
        <unique-id>match-MessageLifecycleEvent</unique-id>
        <connection class="shared-connection">
          <lookup-name>solace-jms-connection</lookup-name>
        </connection>
        <producer class="jms-producer">
          <unique-id>produce-MessageLifecycleEvent</unique-id>
          <acknowledge-mode>CLIENT_ACKNOWLEDGE</acknowledge-mode>
          <message-translator class="text-message-translator">
            <metadata-filter class="remove-all-metadata-filter"/>
          </message-translator>
          <delivery-mode>PERSISTENT</delivery-mode>
          <session-factory class="jms-default-producer-session"/>
          <refresh-session-if-produce-exception>false</refresh-session-if-produce-exception>
          <endpoint>mle/topic</endpoint>
        </producer>
      </standalone-producer>
    </rule>
    <rule>
      <matcher class="regex-event-matcher">
        <regex>com\.adaptris\.core\.HeartbeatEvent</regex>
        <match-type>TYPE</match-type>
      </matcher>
      <standalone-producer>
        <unique-id>match-HeartbeatEvent</unique-id>
        <connection class="shared-connection">
          <lookup-name>solace-jms-connection</lookup-name>
        </connection>
        <producer class="jms-producer">
          <unique-id>produce-HeartbeatEvent</unique-id>
          <acknowledge-mode>CLIENT_ACKNOWLEDGE</acknowledge-mode>
          <message-translator class="text-message-translator">
            <metadata-filter class="remove-all-metadata-filter"/>
          </message-translator>
          <delivery-mode>PERSISTENT</delivery-mode>
          <session-factory class="jms-default-producer-session"/>
          <refresh-session-if-produce-exception>false</refresh-session-if-produce-exception>
          <endpoint>ale/topic</endpoint>
        </producer>
      </standalone-producer>
    </rule>
  </event-handler>
  <heartbeat-event-interval>
    <unit>MINUTES</unit>
    <interval>15</interval>
  </heartbeat-event-interval>
  <message-error-handler class="null-processing-exception-handler">
    <unique-id>null-processing-exception-handle</unique-id>
  </message-error-handler>
  <failed-message-retrier class="no-retries">
    <unique-id>no-retries</unique-id>
  </failed-message-retrier>
  <channel-list>
    <channel>
      <consume-connection class="shared-connection">
        <lookup-name>embedded-jetty-connection</lookup-name>
      </consume-connection>
      <produce-connection class="null-connection">
        <unique-id>ecstatic-lumiere</unique-id>
      </produce-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="jetty-message-consumer">
            <unique-id>send-message-to-destination</unique-id>
            <path>/send-to-jms-destination</path>
            <methods>POST</methods>
            <parameter-handler class="jetty-http-parameters-as-metadata">
              <parameter-prefix>param_</parameter-prefix>
            </parameter-handler>
            <header-handler class="jetty-http-headers-as-object-metadata"/>
          </consumer>
          <service-collection class="service-list">
            <unique-id>sharp-kowalevski</unique-id>
            <services>
              <if-then-otherwise>
                <unique-id>if-jmsDestination-is-empty-return-bad-request</unique-id>
                <condition class="metadata">
                  <operator class="is-empty"/>
                  <metadata-key>param_jmsDestination</metadata-key>
                </condition>
                <then>
                  <service class="service-list">
                    <unique-id>jmsDestination-is-empty</unique-id>
                    <services>
                      <payload-from-template>
                        <unique-id>set-error-message</unique-id>
                        <metadata-tokens/>
                        <template>{"errorDescription":"jmsDestination parameter cannot be empty"}</template>
                      </payload-from-template>
                      <jetty-response-service>
                        <unique-id>return-400-bad-request</unique-id>
                        <http-status>400</http-status>
                        <content-type>application/json</content-type>
                        <response-header-provider class="jetty-no-response-headers"/>
                      </jetty-response-service>
                      <stop-processing-service>
                        <unique-id>stop-processing</unique-id>
                      </stop-processing-service>
                    </services>
                  </service>
                </then>
                <otherwise>
                  <service class="null-service">
                    <unique-id>jmsDestination-not-empty-do-nothing</unique-id>
                  </service>
                </otherwise>
              </if-then-otherwise>
              <metadata-filter-service>
                <unique-id>remove-metadata</unique-id>
                <filter class="regex-metadata-filter">
                  <include-pattern>param_jmsDestination</include-pattern>
                </filter>
              </metadata-filter-service>
              <clone-message-service-list>
                <unique-id>get-metadata-from-payload</unique-id>
                <services>
                  <service-list>
                    <unique-id>get-and-set-metadata</unique-id>
                    <services>
                      <json-path-service>
                        <unique-id>get-metadata</unique-id>
                        <json-path-execution>
                          <source class="constant-data-input-parameter">
                            <value>$.metadata</value>
                          </source>
                          <target class="string-payload-data-output-parameter"/>
                        </json-path-execution>
                        <source class="string-payload-data-input-parameter"/>
                      </json-path-service>
                      <json-to-metadata>
                        <unique-id>set-metadata</unique-id>
                      </json-to-metadata>
                    </services>
                  </service-list>
                </services>
                <override-metadata-filter class="regex-metadata-filter">
                  <include-pattern>^.*$</include-pattern>
                </override-metadata-filter>
                <new-unique-id-per-message>false</new-unique-id-per-message>
              </clone-message-service-list>
              <json-path-service>
                <unique-id>get-payload</unique-id>
                <json-path-execution>
                  <source class="constant-data-input-parameter">
                    <value>$.payload</value>
                  </source>
                  <target class="string-payload-data-output-parameter"/>
                </json-path-execution>
                <source class="string-payload-data-input-parameter"/>
              </json-path-service>
              <if-then-otherwise>
                <unique-id>set-message-unique-id-if-present</unique-id>
                <condition class="metadata">
                  <operator class="not-empty"/>
                  <metadata-key>messageuniqueid</metadata-key>
                </condition>
                <then>
                  <service class="service-list">
                    <unique-id>set-unique-id</unique-id>
                    <services>
                      <if-then-otherwise>
                        <unique-id>if-unique-id-contains-spaces-return-bad-request</unique-id>
                        <condition class="function">
                          <definition>function evaluateScript(message) {
  return /\s/g.test(message.getMetadataValue("messageuniqueid"));
}</definition>
                        </condition>
                        <then>
                          <service class="service-list">
                            <unique-id>unqiue-id-contains-whitespace</unique-id>
                            <services>
                              <payload-from-template>
                                <unique-id>set-error-message</unique-id>
                                <metadata-tokens/>
                                <template>{"errorDescription":"$.metadata.messageuniqueid cannot contain any whitespace"}</template>
                              </payload-from-template>
                              <jetty-response-service>
                                <unique-id>return-400-bad-request</unique-id>
                                <http-status>400</http-status>
                                <content-type>application/json</content-type>
                                <response-header-provider class="jetty-no-response-headers"/>
                              </jetty-response-service>
                              <stop-processing-service>
                                <unique-id>stop-processing</unique-id>
                              </stop-processing-service>
                            </services>
                          </service>
                        </then>
                        <otherwise>
                          <service class="null-service">
                            <unique-id>unqiue-id-does-not-contains-whitespace-do-nothing</unique-id>
                          </service>
                        </otherwise>
                      </if-then-otherwise>
                      <embedded-scripting-service>
                        <unique-id>set-unique-id</unique-id>
                        <language>javascript</language>
                        <script>message.setUniqueId(message.getMetadataValue("messageuniqueid"));</script>
                      </embedded-scripting-service>
                      <metadata-filter-service>
                        <unique-id>remove-unique-id-metadata</unique-id>
                        <filter class="regex-metadata-filter">
                          <exclude-pattern>^messageuniqueid$</exclude-pattern>
                        </filter>
                      </metadata-filter-service>
                    </services>
                  </service>
                </then>
                <otherwise>
                  <service class="service-list">
                    <unique-id>do-nothing</unique-id>
                    <services/>
                  </service>
                </otherwise>
              </if-then-otherwise>
              <add-metadata-service>
                <unique-id>add-destination-metadata</unique-id>
                <metadata-element>
                  <key>produceDestination</key>
                  <value>%message{param_jmsDestination}</value>
                </metadata-element>
              </add-metadata-service>
              <standalone-producer>
                <unique-id>send-to-destination</unique-id>
                <connection class="shared-connection">
                  <lookup-name>solace-jms-connection</lookup-name>
                </connection>
                <producer class="jms-producer">
                  <unique-id>produce-to-destination</unique-id>
                  <acknowledge-mode>CLIENT_ACKNOWLEDGE</acknowledge-mode>
                  <message-translator class="text-message-translator"/>
                  <delivery-mode>PERSISTENT</delivery-mode>
                  <session-factory class="jms-default-producer-session"/>
                  <refresh-session-if-produce-exception>false</refresh-session-if-produce-exception>
                  <endpoint>%message{produceDestination}</endpoint>
                </producer>
              </standalone-producer>
            </services>
          </service-collection>
          <producer class="null-message-producer">
            <unique-id>tiny-borg</unique-id>
          </producer>
          <send-events>false</send-events>
          <unique-id>send-message-to-destination</unique-id>
          <message-metrics-interceptor>
            <unique-id>send-message-to-destination-MessageMetrics</unique-id>
            <timeslice-duration>
              <unit>MINUTES</unit>
              <interval>5</interval>
            </timeslice-duration>
            <timeslice-history-count>12</timeslice-history-count>
          </message-metrics-interceptor>
          <in-flight-workflow-interceptor>
            <unique-id>send-message-to-destination-InFlight</unique-id>
          </in-flight-workflow-interceptor>
        </standard-workflow>
      </workflow-list>
      <message-error-handler class="null-processing-exception-handler">
        <unique-id>null-exception-handler</unique-id>
      </message-error-handler>
      <unique-id>test-inbound</unique-id>
    </channel>
    <channel>
      <consume-connection class="jms-connection">
        <connection-error-handler class="jms-connection-error-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection-2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </consume-connection>
      <produce-connection class="jms-connection">
        <connection-error-handler class="null-connection-error-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection-2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </produce-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="null-message-consumer">
            <unique-id>awesome-golick</unique-id>
          </consumer>
          <service-collection class="service-list">
            <unique-id>boring-hoover</unique-id>
            <services>
              <service-list>
                <unique-id>solace-jms-2</unique-id>
                <services/>
              </service-list>
              <null-service>
                <unique-id>solace-jms-2 2</unique-id>
              </null-service>
              <standalone-producer>
                <unique-id>solace-jms</unique-id>
                <connection class="jms-connection">
                  <connection-state-handler class="solace-connection-state-handler"/>
                  <runtime-component>true</runtime-component>
                  <unique-id>solace-jms-connection-2</unique-id>
                  <connection-attempts>-1</connection-attempts>
                  <user-name>default</user-name>
                  <password>admin</password>
                  <client-id>local_client</client-id>
                  <vendor-implementation class="advanced-solace-implementation">
                    <broker-url>tcp://localhost:55555</broker-url>
                    <message-vpn>default</message-vpn>
                    <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
                    <delivery-mode>PERSISTENT</delivery-mode>
                    <solace-keepalive>
                      <keep-alives>true</keep-alives>
                      <keep-alive-count-max>5</keep-alive-count-max>
                      <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
                    </solace-keepalive>
                    <solace-connection-tuning>
                      <connect-retries>-1</connect-retries>
                      <reconnect-retries>-1</reconnect-retries>
                    </solace-connection-tuning>
                    <properties/>
                  </vendor-implementation>
                </connection>
                <producer class="null-message-producer">
                  <unique-id>affectionate-shirley</unique-id>
                </producer>
              </standalone-producer>
              <standalone-producer>
                <unique-id>solace-jms 2</unique-id>
                <connection class="jms-connection">
                  <connection-state-handler class="solace-connection-state-handler"/>
                  <runtime-component>true</runtime-component>
                  <unique-id>solace-jms-connection-2</unique-id>
                  <connection-attempts>-1</connection-attempts>
                  <user-name>default</user-name>
                  <password>admin</password>
                  <client-id>local_client</client-id>
                  <vendor-implementation class="advanced-solace-implementation">
                    <broker-url>tcp://localhost:55555</broker-url>
                    <message-vpn>default</message-vpn>
                    <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
                    <delivery-mode>PERSISTENT</delivery-mode>
                    <solace-keepalive>
                      <keep-alives>true</keep-alives>
                      <keep-alive-count-max>5</keep-alive-count-max>
                      <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
                    </solace-keepalive>
                    <solace-connection-tuning>
                      <connect-retries>-1</connect-retries>
                      <reconnect-retries>-1</reconnect-retries>
                    </solace-connection-tuning>
                    <properties/>
                  </vendor-implementation>
                </connection>
                <producer class="null-message-producer">
                  <unique-id>affectionate-shirley</unique-id>
                </producer>
              </standalone-producer>
              <standalone-producer>
                <unique-id>solace-jms 3</unique-id>
                <connection class="jms-connection">
                  <connection-state-handler class="solace-connection-state-handler"/>
                  <runtime-component>true</runtime-component>
                  <unique-id>solace-jms-connection-3</unique-id>
                  <connection-attempts>-1</connection-attempts>
                  <user-name>default</user-name>
                  <password>admin</password>
                  <client-id>local_client</client-id>
                  <vendor-implementation class="advanced-solace-implementation">
                    <broker-url>tcp://localhost:55555</broker-url>
                    <message-vpn>default</message-vpn>
                    <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
                    <delivery-mode>PERSISTENT</delivery-mode>
                    <solace-keepalive>
                      <keep-alives>true</keep-alives>
                      <keep-alive-count-max>5</keep-alive-count-max>
                      <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
                    </solace-keepalive>
                    <solace-connection-tuning>
                      <connect-retries>-1</connect-retries>
                      <reconnect-retries>-1</reconnect-retries>
                    </solace-connection-tuning>
                    <properties/>
                  </vendor-implementation>
                </connection>
                <producer class="null-message-producer">
                  <unique-id>affectionate-shirley</unique-id>
                </producer>
              </standalone-producer>
            </services>
          </service-collection>
          <producer class="null-message-producer">
            <unique-id>elegant-bell</unique-id>
          </producer>
          <unique-id>test-channel-2-workflow-1</unique-id>
          <message-metrics-interceptor>
            <unique-id>trusting-mcclintock-MessageMetrics</unique-id>
            <timeslice-duration>
              <unit>MINUTES</unit>
              <interval>5</interval>
            </timeslice-duration>
            <timeslice-history-count>12</timeslice-history-count>
          </message-metrics-interceptor>
          <in-flight-workflow-interceptor>
            <unique-id>trusting-mcclintock-InFlight</unique-id>
          </in-flight-workflow-interceptor>
        </standard-workflow>
      </workflow-list>
      <unique-id>test-channel-2</unique-id>
    </channel>
  </channel-list>
  <message-error-digester class="standard-message-error-digester">
    <unique-id>standard-message-error-digester</unique-id>
    <digest-max-size>100</digest-max-size>
  </message-error-digester>
</adapter>
```

</details>

### Solace Container

<details>

```yaml
services:
  solace:
    image: solace/solace-pubsub-standard:latest
    container_name: solace
    volumes:
      - "storage-group:/var/lib/solace"
    shm_size: 1g
    ulimits:
      core: -1
      nofile:
        soft: 1048576
        hard: 1048576
    deploy:
      restart_policy:
        condition: on-failure
        max_attempts: 1
    ports:
      - '8080:8080'
      - '55555:55555'
      - '8008:8008'
      - '9001:9000'
    environment:
      - username_admin_globalaccesslevel=admin
      - username_admin_password=admin
      - system_scaling_maxconnectioncount=100
    healthcheck:
      test: [ "CMD", "curl", "-f", "http://localhost:8080" ]
volumes:
  storage-group:
```

</details>

- Run Solace Container `docker compose up -d`
- Run Interlok with above config
- `curl -v localhost:{your port}/healthcheck` should return connection status
- `curl -v localhost:{your port}/healthcheck/ready` should return 200
- Stop Solace container, wait until Interlok begins reconnect
- `curl -v localhost:{your port}/healthcheck` should return connection status as stopped
- `curl -v localhost:{your port}/healthcheck/ready` should return 503
